### PR TITLE
reuse pipenv cache and virtualenv dirs

### DIFF
--- a/container-entrypoint.sh
+++ b/container-entrypoint.sh
@@ -16,13 +16,47 @@ if [ $# -eq 1 ] && [ "$1" == "versions" ]; then
   exit 0
 fi
 
+# add user and group 'ats' with the same UID and GID as the user running the image in the host OS
 if [ "${USE_UID:-0}" -ne 0 ] && [ "${USE_GID:-0}" -ne 0 ]; then
   groupadd -f -g "$USE_GID" ats
   groupadd -f -g "$DOCKER_GID" docker
   useradd -g "$USE_GID" -G docker -M -l -u "$USE_UID" ats -d "$ATS_DIR" -s /bin/bash || true
 fi
 
+# if the user in the host OS uses different UID/GID than default, we have to 'chown'
 if [ "${USE_UID:-0}" -ne 1000 ] || [ "${USE_GID:-0}" -ne 1000 ]; then
   chown -R "$USE_UID":"$USE_GID" "$ATS_DIR"
 fi
+
+# if the user in the OS uses different uid/gid for pipenv cache, we have to remember that and chown
+# shellcheck disable=SC2153
+PIPENV_CACHE_UID=$(stat -c '%u' "${PIPENV_CACHE_DIR}")
+PIPENV_CACHE_GID=$(stat -c '%g' "${PIPENV_CACHE_DIR}")
+PIPENV_PERM_CHANGED=0
+if [ "${USE_UID:-0}" -ne "${PIPENV_CACHE_UID}" ] || [ "${USE_GID:-0}" -ne "${PIPENV_CACHE_GID}" ]; then
+  PIPENV_PERM_CHANGED=1
+  chown -R "$USE_UID":"$USE_GID" "$PIPENV_CACHE_DIR"
+fi
+
+# if the user in the OS uses different uid/gid for venvs, we have to remember that and chown
+# shellcheck disable=SC2153
+VENVS_UID=$(stat -c '%u' "${VENVS_DIR}")
+VENVS_GID=$(stat -c '%g' "${VENVS_DIR}")
+VENVS_PERM_CHANGED=0
+if [ "${USE_UID:-0}" -ne "${VENVS_UID}" ] || [ "${USE_GID:-0}" -ne "${VENVS_GID}" ]; then
+  VENVS_PERM_CHANGED=1
+  chown -R "$USE_UID":"$USE_GID" "$VENVS_DIR"
+fi
+
+# run ats
 sudo --preserve-env=PYTHONPATH,PATH -g "#$USE_GID" -u "#$USE_UID" -- python -m app_test_suite "$@"
+
+# revert original permissions on pipenv cache (if changed)
+if [ "${PIPENV_PERM_CHANGED}" -eq 1 ]; then
+  chown -R "$PIPENV_CACHE_UID":"$PIPENV_CACHE_GID" "$PIPENV_CACHE_DIR"
+fi
+
+# revert original permissions on venvs dir (if changed)
+if [ "${VENVS_PERM_CHANGED}" -eq 1 ]; then
+  chown -R "$VENVS_UID":"$VENVS_GID" "$VENVS_DIR"
+fi

--- a/dats.sh
+++ b/dats.sh
@@ -2,11 +2,25 @@
 
 DATS_TAG=${DATS_TAG:-"0.1.3"}
 
+# Please Note
+# This script tries to speed up python tests execution by using pipenv cache and reusing virtualenvs.
+# To make this work on CI systems, you have to ensure that $PIPENV_CACHE_DIR and $VENVS_DIR
+# listed below are persisted between CI system runs.
+
+# don't override variables below
+ATS_DIR="/ats"
+PIPENV_CACHE_DIR=".cache/pipenv"
+VENVS_DIR=".local/share/virtualenvs"
+
 docker run -it --rm \
   -e USE_UID="$(id -u "${USER}")" \
   -e USE_GID="$(id -g "${USER}")" \
   -e DOCKER_GID="$(getent group docker | cut -d: -f3)" \
-  -v "$(pwd)":/ats/workdir/ \
+  -e PIPENV_CACHE_DIR="${ATS_DIR}/${PIPENV_CACHE_DIR}" \
+  -e VENVS_DIR="${ATS_DIR}/${VENVS_DIR}" \
+  -v "$(pwd):${ATS_DIR}/workdir/" \
+  -v "${HOME}/${PIPENV_CACHE_DIR}:${ATS_DIR}/${PIPENV_CACHE_DIR}" \
+  -v "${HOME}/${VENVS_DIR}:${ATS_DIR}/${VENVS_DIR}" \
   -v /var/run/docker.sock:/var/run/docker.sock \
   --network host \
   "quay.io/giantswarm/app-test-suite:${DATS_TAG}" "$@"


### PR DESCRIPTION
This shows how far a man that should not run stuff in a container can go to make stuff run in a container.
Check `dats.sh` for a short info.

Closes: https://github.com/giantswarm/roadmap/issues/493