### PR TITLE
add extra-test-info; use it to provide upgrade stage info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ following [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+- Added
+  - Test executors can now get extra info about the test run. Currently, used to provide info about
+    upgrade test execution stage.
+
 ## [0.2.2] - 2021-11-17
 
 - Fixed

--- a/app_test_suite/steps/base.py
+++ b/app_test_suite/steps/base.py
@@ -5,7 +5,7 @@ import shutil
 from abc import ABC
 from dataclasses import dataclass
 from tempfile import TemporaryDirectory
-from typing import Set, Optional, List
+from typing import Set, Optional, List, Dict
 
 import configargparse
 import yaml
@@ -122,6 +122,8 @@ class TestExecInfo:
     """Type of test to execute by the test executor."""
     debug: bool
     """Should the test engine be run with debug enabled."""
+    test_extra_info: Optional[Dict[str, str]] = None
+    """Optional dict of key-value pairs that will be passed to the test executor"""
 
 
 class TestExecutor(ABC):

--- a/app_test_suite/steps/executors/gotest.py
+++ b/app_test_suite/steps/executors/gotest.py
@@ -74,6 +74,9 @@ class GotestExecutor(TestExecutor):
             "PATH": os.getenv("PATH", ""),
         }
 
+        if exec_info.test_extra_info:
+            env_vars.update({"ATS_" + k.upper(): v for k, v in exec_info.test_extra_info.items()})
+
         if exec_info.app_config_file_path is not None:
             env_vars["ATS_APP_CONFIG_FILE_PATH"] = exec_info.app_config_file_path
 

--- a/app_test_suite/steps/executors/pytest.py
+++ b/app_test_suite/steps/executors/pytest.py
@@ -97,6 +97,8 @@ class PytestExecutor(TestExecutor):
         ]
         if exec_info.app_config_file_path:
             args += ["--values-file", exec_info.app_config_file_path]
+        if exec_info.test_extra_info:
+            args += ["--test-extra-info", ",".join([f"ATS_{k}={v}" for k, v in exec_info.test_extra_info.items()])]
         logger.info(f"Running {self._PYTEST_BIN} tool in '{self._test_dir}' directory.")
         run_res = run_and_log(args, cwd=self._test_dir)  # nosec, no user input here
         # exit code 5 from pytest means that no tests matched the selector - it's not an error for us

--- a/app_test_suite/steps/executors/pytest.py
+++ b/app_test_suite/steps/executors/pytest.py
@@ -98,7 +98,7 @@ class PytestExecutor(TestExecutor):
         if exec_info.app_config_file_path:
             args += ["--values-file", exec_info.app_config_file_path]
         if exec_info.test_extra_info:
-            args += ["--test-extra-info", ",".join([f"ATS_{k}={v}" for k, v in exec_info.test_extra_info.items()])]
+            args += ["--test-extra-info", ",".join([f"ats_{k}={v}" for k, v in exec_info.test_extra_info.items()])]
         logger.info(f"Running {self._PYTEST_BIN} tool in '{self._test_dir}' directory.")
         run_res = run_and_log(args, cwd=self._test_dir)  # nosec, no user input here
         # exit code 5 from pytest means that no tests matched the selector - it's not an error for us

--- a/tests/scenarios/executors/gotest.py
+++ b/tests/scenarios/executors/gotest.py
@@ -10,7 +10,9 @@ import app_test_suite.steps.executors.gotest
 from tests.helpers import MOCK_KUBE_VERSION
 
 
-def assert_run_gotest(test_provided: StepType, kube_config_path: str, chart_file: str, app_version: str) -> None:
+def assert_run_gotest(
+    test_provided: StepType, kube_config_path: str, chart_file: str, app_version: str, test_extra_info: str = ""
+) -> None:
     env_vars = {
         "ATS_APP_CONFIG_FILE_PATH": "",
         "ATS_CHART_PATH": chart_file,
@@ -25,6 +27,8 @@ def assert_run_gotest(test_provided: StepType, kube_config_path: str, chart_file
         "HOME": os.getenv("HOME", ""),
         "PATH": os.getenv("PATH", ""),
     }
+    if test_extra_info:
+        env_vars.update({k.upper(): v for k, v in [p.split("=") for p in test_extra_info.split(",")]})
 
     cast(unittest.mock.Mock, app_test_suite.steps.executors.gotest.run_and_handle_error).assert_any_call(
         [

--- a/tests/scenarios/executors/pytest.py
+++ b/tests/scenarios/executors/pytest.py
@@ -9,30 +9,33 @@ import app_test_suite.steps.executors.pytest
 from tests.helpers import MOCK_KUBE_VERSION
 
 
-def assert_run_pytest(test_provided: StepType, kube_config_path: str, chart_file: str, app_version: str) -> None:
-    cast(unittest.mock.Mock, app_test_suite.steps.executors.pytest.run_and_log).assert_any_call(
-        [
-            "pipenv",
-            "run",
-            "pytest",
-            "-m",
-            test_provided,
-            "--cluster-type",
-            "mock",
-            "--kube-config",
-            kube_config_path,
-            "--chart-path",
-            chart_file,
-            "--chart-version",
-            app_version,
-            "--chart-extra-info",
-            f"external_cluster_version={MOCK_KUBE_VERSION}",
-            "--log-cli-level",
-            "info",
-            f"--junitxml=test_results_{test_provided}.xml",
-        ],
-        cwd="",
-    )
+def assert_run_pytest(
+    test_provided: StepType, kube_config_path: str, chart_file: str, app_version: str, test_extra_info: str = ""
+) -> None:
+    expected_args = [
+        "pipenv",
+        "run",
+        "pytest",
+        "-m",
+        test_provided,
+        "--cluster-type",
+        "mock",
+        "--kube-config",
+        kube_config_path,
+        "--chart-path",
+        chart_file,
+        "--chart-version",
+        app_version,
+        "--chart-extra-info",
+        f"external_cluster_version={MOCK_KUBE_VERSION}",
+        "--log-cli-level",
+        "info",
+        f"--junitxml=test_results_{test_provided}.xml",
+    ]
+    if test_extra_info:
+        expected_args.append("--test-extra-info")
+        expected_args.append(test_extra_info)
+    cast(unittest.mock.Mock, app_test_suite.steps.executors.pytest.run_and_log).assert_any_call(expected_args, cwd="")
 
 
 def assert_prepare_pytest_test_environment() -> None:

--- a/tests/scenarios/test_upgrade_scenario.py
+++ b/tests/scenarios/test_upgrade_scenario.py
@@ -162,7 +162,7 @@ def test_upgrade_pytest_runner_run(
     mocker: MockerFixture,
     test_executor: TestExecutor,
     patcher: Callable[[MockerFixture, unittest.mock.Mock], None],
-    asserter_test: Callable[[StepType, str, str, str], None],
+    asserter_test: Callable[[StepType, str, str, str, str], None],
     asserter_prepare: Callable[[], None],
 ) -> None:
     mock_cluster_manager = get_mock_cluster_manager(mocker)
@@ -190,7 +190,13 @@ def test_upgrade_pytest_runner_run(
     )
     asserter_prepare()
     mock_stable_app_catalog_cr.create.assert_any_call()
-    asserter_test(runner.test_provided, MOCK_KUBE_CONFIG_PATH, MOCK_UPGRADE_CHART_FILE_URL, MOCK_UPGRADE_APP_VERSION)
+    asserter_test(
+        runner.test_provided,
+        MOCK_KUBE_CONFIG_PATH,
+        MOCK_UPGRADE_CHART_FILE_URL,
+        MOCK_UPGRADE_APP_VERSION,
+        "ats_upgrade_test_stage=pre_upgrade",
+    )
     assert_upgrade_tester_exec_hook(
         KEY_PRE_UPGRADE,
         MOCK_APP_NAME,
@@ -208,7 +214,13 @@ def test_upgrade_pytest_runner_run(
         MOCK_KUBE_CONFIG_PATH,
         MOCK_APP_DEPLOY_NS,
     )
-    asserter_test(runner.test_provided, MOCK_KUBE_CONFIG_PATH, MOCK_CHART_FILE_NAME, MOCK_CHART_VERSION)
+    asserter_test(
+        runner.test_provided,
+        MOCK_KUBE_CONFIG_PATH,
+        MOCK_CHART_FILE_NAME,
+        MOCK_CHART_VERSION,
+        "ats_upgrade_test_stage=post_upgrade",
+    )
     mock_requests_get_chart.assert_called_once_with(MOCK_UPGRADE_CHART_FILE_URL, allow_redirects=True)
     assert_upgrade_tester_deletes_app(configured_app_mock)
     mock_stable_app_catalog_cr.delete.assert_called_once()


### PR DESCRIPTION
This PR adds a key-value bag to pass any extra info about the test executed to test executors. It is already used to provide information about upgrade stage (pre-upgrade, post-upgrade).