### PR TITLE
Update apptestctl to v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ following [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+- Changed
+  - Update apptestctl to v0.14.0.
+
 ## [0.2.3-beta.1] - 2022-01-04
 
 - Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG KUBECTL_VER="1.21.2"
 ARG DOCKER_VER="20.10.9"
 # upgrade to kind 0.10.0 held, as it defaults to kubernetes 1.20; we're still targeting primarly 1.19
 ARG KIND_VER="0.11.1"
-ARG APPTESTCTL_VER="0.12.0"
+ARG APPTESTCTL_VER="0.14.0"
 
 RUN apk add --no-cache ca-certificates curl \
     && mkdir -p /binaries \


### PR DESCRIPTION
Updates to use the latest app-operator and chart-operator with helm v3.6.3.
Also reduces verbosity of the logs a lot.