### PR TITLE
Run with kubernetes version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ following [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+- Added
+  - Add `--kind-cluster-image-override` flag make it possible to augment an existing kind config
+    file to override the used kind node container image.
 - Changed
   - Update apptestctl to v0.14.0.
 

--- a/app_test_suite/cluster_providers/kind_cluster_provider.py
+++ b/app_test_suite/cluster_providers/kind_cluster_provider.py
@@ -104,7 +104,8 @@ class KindClusterProvider(cluster_provider.ClusterProvider):
     def augment_kind_config_file(self, kind_config_path: str, image_override: str) -> str:
         with open(kind_config_path, "r") as file:
             config_yaml = yaml.safe_load(file)
-            config_yaml["nodes"] = [dict(node, **{"image": image_override}) for node in config_yaml["nodes"]]
+            for node in config_yaml["nodes"]:
+                node.update({"image": image_override})
 
         tmp_dir = mkdtemp(prefix="ats-")
         augmented_kind_config_path = os.path.join(tmp_dir, "kind_config.yaml")

--- a/app_test_suite/cluster_providers/kind_cluster_provider.py
+++ b/app_test_suite/cluster_providers/kind_cluster_provider.py
@@ -71,7 +71,7 @@ class KindClusterProvider(cluster_provider.ClusterProvider):
             )
             if kind_cluster_image_override:
                 config_file = self.augment_kind_config_file(config_file, kind_cluster_image_override)
-            logger.info(f"Using KinD config {config_file} with ID kind node image '{kind_cluster_image_override}'")
+                logger.info(f"Using KinD config {config_file} with ID kind node image '{kind_cluster_image_override}'")
             kind_args.extend(["--config", config_file])
         run_res = run_and_log(kind_args, capture_output=True)  # nosec
         logger.debug(run_res.stderr)


### PR DESCRIPTION
This PR adds the ability to run tests on different kubernetes versions on kind clusters.

For this the new flag `--kind-cluster-image-override` augments a given kind config to spin up a cluster with the given kind node container image.