### PR TITLE
Add flag to skip app deletion after tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ following [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+- Added
+  - Add `--app-tests-skip-app-delete` flag to allow skipping App CR and ConfigMap deletion after tests.
+
 ## [0.2.3] - 2022-01-04
 
 - Added

--- a/app_test_suite/steps/base.py
+++ b/app_test_suite/steps/base.py
@@ -30,6 +30,7 @@ class BaseTestScenariosFilteringPipeline(BuildStepsFilteringPipeline):
 
     KEY_CONFIG_GROUP_NAME = "Base app testing options"
     KEY_CONFIG_OPTION_SKIP_DEPLOY_APP = "--app-tests-skip-app-deploy"
+    KEY_CONFIG_OPTION_SKIP_DELETE_APP = "--app-tests-skip-app-delete"
     KEY_CONFIG_OPTION_DEPLOY_NAMESPACE = "--app-tests-deploy-namespace"
     KEY_CONFIG_OPTION_DEPLOY_CONFIG_FILE = "--app-tests-app-config-file"
 
@@ -52,6 +53,12 @@ class BaseTestScenariosFilteringPipeline(BuildStepsFilteringPipeline):
             required=False,
             action="store_true",
             help="Skip automated app deployment for the test run to the test cluster (using an App CR).",
+        )
+        self._config_parser_group.add_argument(
+            self.KEY_CONFIG_OPTION_SKIP_DELETE_APP,
+            required=False,
+            action="store_true",
+            help="Skip automated App CR and ConfigMap deletion for the test run to the test cluster.",
         )
         self._config_parser_group.add_argument(
             self.KEY_CONFIG_OPTION_DEPLOY_NAMESPACE,

--- a/app_test_suite/steps/scenarios/simple.py
+++ b/app_test_suite/steps/scenarios/simple.py
@@ -230,6 +230,8 @@ class SimpleTestScenario(BuildStep, ABC):
         finally:
             if not get_config_value_by_cmd_line_option(
                 config, BaseTestScenariosFilteringPipeline.KEY_CONFIG_OPTION_SKIP_DEPLOY_APP
+            ) and not get_config_value_by_cmd_line_option(
+                config, BaseTestScenariosFilteringPipeline.KEY_CONFIG_OPTION_SKIP_DELETE_APP
             ):
                 self._delete_app(config, context)
 


### PR DESCRIPTION
This PR adds `--app-tests-skip-app-delete` flag to allow skipping App CR and ConfigMap deletion after tests.

In combination with external clusters, this flag is useful for debugging tests.