### PR TITLE
Log go test outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ following [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+- Added
+  - Display logs for go test commands to make it easier to debug failing tests
+
 ## [0.2.3] - 2022-01-04
 
 - Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,6 +71,8 @@ COPY app_test_suite/ ${ATS_DIR}/app_test_suite/
 
 WORKDIR $ATS_DIR/workdir
 
+RUN mkdir -p ${ATS_DIR}/.cache/go-build
+
 # we assume the user will be using UID==1000 and GID=1000; if that's not true, we'll run `chown`
 # in the container's startup script
 RUN chown -R 1000:1000 $ATS_DIR

--- a/app_test_suite/steps/executors/gotest.py
+++ b/app_test_suite/steps/executors/gotest.py
@@ -98,12 +98,12 @@ class GotestExecutor(TestExecutor):
 
         logger.info("#" * 40)
         logger.info("Command STDOUT was:")
-        for line in run_res.stdout:
+        for line in run_res.stdout.splitlines():
             logger.info(line)
 
         logger.info("#" * 40)
         logger.info("Command STDERR was:")
-        for line in run_res.stderr:
+        for line in run_res.stderr.splitlines():
             logger.info(line)
 
         if run_res.returncode != 0:

--- a/app_test_suite/steps/executors/gotest.py
+++ b/app_test_suite/steps/executors/gotest.py
@@ -106,6 +106,8 @@ class GotestExecutor(TestExecutor):
         for line in run_res.stderr.splitlines():
             logger.info(line)
 
+        logger.info("#" * 40)
+
         if run_res.returncode != 0:
             raise ATSTestError(f"Gotest tests failed: running '{args}' in directory '{self._test_dir}' failed.")
 

--- a/app_test_suite/steps/executors/gotest.py
+++ b/app_test_suite/steps/executors/gotest.py
@@ -92,6 +92,20 @@ class GotestExecutor(TestExecutor):
         run_res = run_and_handle_error(
             args, "build constraints exclude all Go files", cwd=self._test_dir, env=env_vars
         )  # nosec, no user input here
+
+        logger.info("#" * 40)
+        logger.info(f"Command '{args}' executed, exit code: {run_res.returncode}")
+
+        logger.info("#" * 40)
+        logger.info("Command STDOUT was:")
+        for line in run_res.stdout:
+            logger.info(line)
+
+        logger.info("#" * 40)
+        logger.info("Command STDERR was:")
+        for line in run_res.stderr:
+            logger.info(line)
+
         if run_res.returncode != 0:
             raise ATSTestError(f"Gotest tests failed: running '{args}' in directory '{self._test_dir}' failed.")
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -98,6 +98,8 @@ def get_base_config(mocker: MockerFixture) -> Namespace:
 def get_run_and_log_result_mock(mocker: MockerFixture) -> unittest.mock.Mock:
     system_call_result_mock = mocker.Mock(name="SysCallResult")
     type(system_call_result_mock).returncode = mocker.PropertyMock(return_value=0)
+    type(system_call_result_mock).stdout = mocker.PropertyMock(return_value="")
+    type(system_call_result_mock).stderr = mocker.PropertyMock(return_value="")
     return system_call_result_mock
 
 


### PR DESCRIPTION
We capture the output and it is not displayed on the CI logs so we do not know why it failed when it does, [for example](https://app.circleci.com/pipelines/github/giantswarm/app-exporter/1096/workflows/495feeef-ce78-45cc-87cd-054637d655ea/jobs/5397).