### PR TITLE
Make kind create cluster --image X kustomizable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ following [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+- Added
+  - Add `--kind-cluster-image` flag to configure the image used to create kind clusters, defaults to `kindest/node:v1.24.6` because that is the last version that supports PSPs that we still use in some places
+
 ## [0.2.7] - 2022-10-19
 
 - Changed

--- a/app_test_suite/__main__.py
+++ b/app_test_suite/__main__.py
@@ -79,6 +79,12 @@ def configure_global_options(config_parser: configargparse.ArgParser) -> None:
         required=False,
         default=[],
     )
+    config_parser.add_argument(
+        "--kindest-node-version",
+        required=False,
+        default="v1.24.6",
+        help="The kindest/node docker image to use for booting a kind cluster",
+    )
 
 
 def configure_test_specific_options(config_parser: configargparse.ArgParser) -> None:

--- a/app_test_suite/__main__.py
+++ b/app_test_suite/__main__.py
@@ -83,7 +83,7 @@ def configure_global_options(config_parser: configargparse.ArgParser) -> None:
         "--kind-cluster-image",
         required=False,
         default="kindest/node:v1.24.6",
-        help="The kindest/node docker image to use for booting a kind cluster",
+        help="The container image to use for booting a kind cluster",
     )
 
 

--- a/app_test_suite/__main__.py
+++ b/app_test_suite/__main__.py
@@ -80,9 +80,9 @@ def configure_global_options(config_parser: configargparse.ArgParser) -> None:
         default=[],
     )
     config_parser.add_argument(
-        "--kindest-node-version",
+        "--kind-cluster-image",
         required=False,
-        default="v1.24.6",
+        default="kindest/node:v1.24.6",
         help="The kindest/node docker image to use for booting a kind cluster",
     )
 

--- a/app_test_suite/cluster_providers/kind_cluster_provider.py
+++ b/app_test_suite/cluster_providers/kind_cluster_provider.py
@@ -62,10 +62,15 @@ class KindClusterProvider(cluster_provider.ClusterProvider):
         cluster_name = str(uuid.uuid4())
         kube_config_path = self.__get_kube_config_from_name(cluster_name)
         kind_args = [
-            self._kind_bin, "create", "cluster",
-            "--name", cluster_name,
-            "--image", config.kindest_node_version,
-            "--kubeconfig", kube_config_path
+            self._kind_bin,
+            "create",
+            "cluster",
+            "--name",
+            cluster_name,
+            "--image",
+            config.kindest_node_version,
+            "--kubeconfig",
+            kube_config_path,
         ]
         logger.info(f"Creating KinD cluster with ID '{cluster_name}'...")
         config_file = ""

--- a/app_test_suite/cluster_providers/kind_cluster_provider.py
+++ b/app_test_suite/cluster_providers/kind_cluster_provider.py
@@ -68,7 +68,7 @@ class KindClusterProvider(cluster_provider.ClusterProvider):
             "--name",
             cluster_name,
             "--image",
-            config.kindest_node_version,
+            config.kind_cluster_image,
             "--kubeconfig",
             kube_config_path,
         ]

--- a/app_test_suite/cluster_providers/kind_cluster_provider.py
+++ b/app_test_suite/cluster_providers/kind_cluster_provider.py
@@ -61,7 +61,12 @@ class KindClusterProvider(cluster_provider.ClusterProvider):
     ) -> cluster_provider.ClusterInfo:
         cluster_name = str(uuid.uuid4())
         kube_config_path = self.__get_kube_config_from_name(cluster_name)
-        kind_args = [self._kind_bin, "create", "cluster", "--name", cluster_name, "--kubeconfig", kube_config_path]
+        kind_args = [
+            self._kind_bin, "create", "cluster",
+            "--name", cluster_name,
+            "--image", config.kindest_node_version,
+            "--kubeconfig", kube_config_path
+        ]
         logger.info(f"Creating KinD cluster with ID '{cluster_name}'...")
         config_file = ""
         if "config_file" in kwargs and kwargs["config_file"]:


### PR DESCRIPTION
Because the used version of kind created 1.25 kubernetes clusters where PSPs are not supported anymore - the CRD is not present - and this causes our older installations to fails.