### PR TITLE
Update apptestctl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,6 +71,9 @@ COPY --from=builder ${ATS_DIR}/.venv ${ATS_DIR}/.venv
 
 COPY --from=binaries /binaries/* /usr/local/bin/
 
+# remove once apptestctl has a proper release
+COPY --from=quay.io/giantswarm/apptestctl:0.15.0-0e74316f8d8af46a2e13ea012aa63ae4701ff93c /usr/local/bin/apptestctl /usr/local/bin/apptestctl
+
 COPY app_test_suite/ ${ATS_DIR}/app_test_suite/
 
 WORKDIR $ATS_DIR/workdir

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ COPY container-entrypoint.sh /binaries
 RUN chmod +x /binaries/*
 
 
-FROM python:3.9.7-slim AS base
+FROM python:3.9.16-slim AS base
 
 ENV LANG=C.UTF-8 \
     LC_ALL=C.UTF-8 \


### PR DESCRIPTION
This PR uses an unreleased apptestctl towards making app-test-suite working on k8s 1.25