### PR TITLE
Update apptestctl to v0.17.0 for ServiceMonitor and PodMonitor CRDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ following [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+- Changed
+  - Update `apptestctl` to 0.17.0 for ServiceMonitor and PodMonitor CRD
+
 ## [0.3.0] - 2023-05-15
 
 - Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG DOCKER_VER=v24.0.1
 # renovate: datasource=github-releases depName=kubernetes-sigs/kind
 ARG KIND_VER=v0.17.0
 # renovate: datasource=github-releases depName=giantswarm/apptestctl
-ARG APPTESTCTL_VER=v0.16.0
+ARG APPTESTCTL_VER=v0.17.0
 
 RUN apk add --no-cache ca-certificates curl \
     && mkdir -p /binaries \


### PR DESCRIPTION
This PR updates apptestctl to version 0.17.0 in order to install ServiceMonitor and PodMonitor CRDs on test clusters.

Towards https://github.com/giantswarm/giantswarm/issues/27145