### PR TITLE
Change registry from quay.io to gsoci.azurecr.io

### DIFF
--- a/Makefile.ats.mk
+++ b/Makefile.ats.mk
@@ -1,5 +1,5 @@
 # Image URL to use all building/pushing image targets
-IMG ?= quay.io/giantswarm/app-test-suite
+IMG ?= gsoci.azurecr.io/giantswarm/app-test-suite
 
 export VER ?= $(shell git describe --tags --abbrev=0 2>/dev/null || echo "0.0.0")
 export COMMIT ?= $(shell git rev-parse HEAD 2>/dev/null || echo "0000000000000000000000000000000000000000")

--- a/dats.sh
+++ b/dats.sh
@@ -23,4 +23,4 @@ docker run -it --rm \
   -v "${HOME}/${VENVS_DIR}:${ATS_DIR}/${VENVS_DIR}" \
   -v /var/run/docker.sock:/var/run/docker.sock \
   --network host \
-  "quay.io/giantswarm/app-test-suite:${DATS_TAG}" "$@"
+  "gsoci.azurecr.io/giantswarm/app-test-suite:${DATS_TAG}" "$@"

--- a/testrunner.Dockerfile
+++ b/testrunner.Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/giantswarm/app-test-suite:latest
+FROM gsoci.azurecr.io/giantswarm/app-test-suite:latest
 
 ARG ATS_DIR="/ats"
 


### PR DESCRIPTION
Found a few places where we can switch from quay to gsoci.