### PR TITLE
feat: add keep-going mode to run all test steps before reporting errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), following
 
 ## [Unreleased]
 
+### Added
+
+- `--keep-going` flag: all test steps run to completion even when earlier steps fail; errors are reported together at the end. Requires `step-exec-lib >= 0.5.0`.
+
 ## [0.15.0] - 2026-04-02
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), following
 
 ### Added
 
-- `--keep-going` flag: all test steps run to completion even when earlier steps fail; errors are reported together at the end. Requires `step-exec-lib >= 0.5.0`.
+- Keep-going mode: all test steps run to completion even when earlier steps fail; errors are reported together at the end. Enabled by default; use `--no-keep-going` to stop on first failure. Requires `step-exec-lib >= 0.5.0`.
 
 ## [0.15.0] - 2026-04-02
 

--- a/app_test_suite/__main__.py
+++ b/app_test_suite/__main__.py
@@ -71,7 +71,7 @@ def configure_global_options(config_parser: configargparse.ArgParser) -> None:
         required=False,
         default=True,
         action=argparse.BooleanOptionalAction,
-        help="Run all steps even if some fail, then report all errors at the end. Use --no-keep-going to stop on first failure.",
+        help="Collect all errors before failing instead of stopping on the first failure. Full pipeline support requires step-exec-lib >= 0.5.0. Use --no-keep-going for fail-fast behaviour.",
     )
     steps_group = config_parser.add_mutually_exclusive_group()
     steps_group.add_argument(

--- a/app_test_suite/__main__.py
+++ b/app_test_suite/__main__.py
@@ -1,5 +1,6 @@
 """Main module. Loads configuration and executes main control loops."""
 
+import argparse
 import logging
 import os
 import sys
@@ -68,9 +69,9 @@ def configure_global_options(config_parser: configargparse.ArgParser) -> None:
     config_parser.add_argument(
         "--keep-going",
         required=False,
-        default=False,
-        action="store_true",
-        help="Run all steps even if some fail, then report all errors at the end.",
+        default=True,
+        action=argparse.BooleanOptionalAction,
+        help="Run all steps even if some fail, then report all errors at the end. Use --no-keep-going to stop on first failure.",
     )
     steps_group = config_parser.add_mutually_exclusive_group()
     steps_group.add_argument(

--- a/app_test_suite/__main__.py
+++ b/app_test_suite/__main__.py
@@ -65,6 +65,13 @@ def configure_global_options(config_parser: configargparse.ArgParser) -> None:
         help="Type of test executor. Either pytest or gotest.",
     )
     config_parser.add_argument("--version", action="version", version=f"{app_name} {get_version()}")
+    config_parser.add_argument(
+        "--keep-going",
+        required=False,
+        default=False,
+        action="store_true",
+        help="Run all steps even if some fail, then report all errors at the end.",
+    )
     steps_group = config_parser.add_mutually_exclusive_group()
     steps_group.add_argument(
         "--steps",


### PR DESCRIPTION
## Summary

All test steps now run to completion by default before reporting errors, instead of stopping on the first failure. Use `--no-keep-going` to restore fail-fast behavior.

- Adds keep-going mode via `step-exec-lib >= 0.5.0` `Runner` and `BuildStepsFilteringPipeline`
- `--keep-going` defaults to `true`; `--no-keep-going` opts out
- Rebased onto current main (uv migration, dependency updates)