### PR TITLE
fix: upgrade codecov orb from v5.4.3 to v6.0.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
     architect: giantswarm/architect@8.2.2
-    codecov: codecov/codecov@5.4.3
+    codecov: codecov/codecov@6.0.0
 
 workflows:
     test:


### PR DESCRIPTION
Codecov migrated their CLI signing key from `keybase.io/codecovsecurity` to `keybase.io/codecovsecops` in June 2024 and deleted the old account. The `codecov/codecov` orb v5.x still references the old key, causing every CI build to fail at the `(Codecov) Validate CLI` step.

v6.0.0 (released June 7, 2026) ships with the updated key reference and fixes the validation failure.

This unblocks all open renovate PRs which are currently failing with the same error.