### PR TITLE
feat(deploy)!: deploy charts with helm instead of App CR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,15 @@ Based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), following
 
 ### Added
 
+- Test suites receive `ATS_RELEASE_NAME` and `ATS_RELEASE_NAMESPACE` environment variables identifying the deployed Helm release and the namespace it was installed into.
+- `helm` is now bundled in the ATS Docker image (renovate-pinned).
 - Keep-going mode: all test steps run to completion even when earlier steps fail; errors are reported together at the end. Enabled by default; use `--no-keep-going` to stop on first failure. Requires `step-exec-lib >= 0.5.0`.
 - Docker image is now published for `linux/amd64` and `linux/arm64`.
 
 ### Changed
 
+- **BREAKING:** Smoke, functional, and upgrade scenarios now deploy the chart under test directly with Helm (`helm upgrade --install`, `helm uninstall`) instead of creating an `App` CR. The upgrade scenario installs the stable chart, runs `helm upgrade` to the version under test, and uninstalls with Helm. Test suites that read the `App` CR must instead assert against the deployed workloads via the kube client, using `ATS_RELEASE_NAME` / `ATS_RELEASE_NAMESPACE`. Values files continue to be passed through `--app-tests-app-config-file` (forwarded to `helm --values`).
+- **BREAKING:** During the pre-upgrade test phase, `ATS_CHART_PATH` is now the local path of the stable chart `.tgz` instead of a remote chartmuseum URL. Test suites that fetched it as a URL must read it as a filesystem path.
 - **BREAKING:** `PytestExecutor` now uses `uv sync` / `uv run pytest` instead of `pipenv install --deploy` /
   `pipenv run pytest`. App test directories must provide `pyproject.toml` + `uv.lock` instead of `Pipfile` /
   `Pipfile.lock`. `pipenv` is no longer installed in the ATS Docker image.
@@ -26,6 +30,10 @@ Based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), following
 
   Commit `pyproject.toml` and `uv.lock`. See [docs/pytest-test-pipeline.md](docs/pytest-test-pipeline.md)
   for full instructions.
+
+### Fixed
+
+- `--app-tests-skip-app-delete` now prevents teardown of the deployed chart. It was previously ignored whenever the chart had been deployed (only honored when `--app-tests-skip-app-deploy` was also set).
 
 ### Removed
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ WORKDIR $ATS_DIR
 
 FROM base AS builder
 
-ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
+ENV UV_LINK_MODE=copy
 
 # Omit development dependencies
 ENV UV_NO_DEV=1

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ ARG DOCKER_VER=v28.5.2
 ARG KIND_VER=v0.32.0
 # renovate: datasource=github-releases depName=giantswarm/apptestctl
 ARG APPTESTCTL_VER=v0.25.1
+# renovate: datasource=github-releases depName=helm/helm
+ARG HELM_VER=v4.2.2
 
 RUN apk add --no-cache ca-certificates curl \
     && mkdir -p /binaries \
@@ -19,6 +21,8 @@ RUN apk add --no-cache ca-certificates curl \
     tar --extract --gzip --directory /binaries --strip-components 1 apptestctl-${APPTESTCTL_VER}-linux-${TARGETARCH}/apptestctl \
     && curl --silent --show-error --fail --location https://download.docker.com/linux/static/stable/${DOCKER_ARCH}/docker-${DOCKER_VER##v}.tgz | \
     tar --extract --gzip --directory /binaries --strip-components 1 docker/docker \
+    && curl --silent --show-error --fail --location https://get.helm.sh/helm-${HELM_VER}-linux-${TARGETARCH}.tar.gz | \
+    tar --extract --gzip --directory /binaries --strip-components 1 linux-${TARGETARCH}/helm \
     && curl --silent --show-error --fail --location https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VER}/kind-linux-${TARGETARCH} --output /binaries/kind
 
 COPY container-entrypoint.sh /binaries

--- a/README.md
+++ b/README.md
@@ -106,13 +106,12 @@ Each run consist of two stages: bootstrapping and test execution.
 
 - if you configured your run with `*-tests-cluster-type kind`, a cluster is created with `kind` tool
 - `ats` connects to the target test cluster and runs [`apptestctl`](https://github.com/giantswarm/apptestctl) -
-  an additional tool that deploys components of App Platform
-  (`app-operator`, `chart-operator` and CRDs they use)
-- `ats` deploys `chart-museum`: a simple helm chart registry that will be used to store your chart under test
-- creates `Catalog` CR for the chart repository provided by `chart-museum`
-- creates `App` CR for your chart: as a result, your application defined in the chart is already deployed to the test
-  cluster (you can disable creating this app with `app-tests-skip-app-deploy` option; this might be needed if you
-  need more control over your test, like: setup additional CRDs or install additional apps).
+  an additional tool that installs the CRDs your chart may reference
+- `ats` deploys your chart under test directly with Helm (`helm upgrade --install`); your application defined in the
+  chart is deployed to the test cluster (you can disable this with the `app-tests-skip-app-deploy` option; this might
+  be needed if you need more control over your test, like setting up additional CRDs or installing additional apps).
+  The deployed release name and namespace are exposed to your tests via the `ATS_RELEASE_NAME` and
+  `ATS_RELEASE_NAMESPACE` environment variables.
 
 After that, `ats` hands control over to your tests.
 
@@ -150,6 +149,9 @@ uv sync
     ATS_CHART_PATH="hello-world-app-0.1.8-1112d08fc7d610a61ace4233a4e8aecda54118db.tgz"
     ATS_CHART_VERSION="0.1.8-1112d08fc7d610a61ace4233a4e8aecda54118db"
 
+    ATS_RELEASE_NAME="hello-world-app"
+    ATS_RELEASE_NAMESPACE="default"
+
     uv run pytest --log-cli-level info --junitxml=test_results_smoke.xml
 )
 
@@ -167,6 +169,9 @@ uv sync
 
     ATS_CHART_PATH="hello-world-app-0.1.8-1112d08fc7d610a61ace4233a4e8aecda54118db.tgz"
     ATS_CHART_VERSION="0.1.8-1112d08fc7d610a61ace4233a4e8aecda54118db"
+
+    ATS_RELEASE_NAME="hello-world-app"
+    ATS_RELEASE_NAMESPACE="default"
 
     uv run pytest --log-cli-level info --junitxml=test_results_functional.xml
 )

--- a/app_test_suite/steps/base.py
+++ b/app_test_suite/steps/base.py
@@ -130,6 +130,10 @@ class TestExecInfo:
     """Should the test engine be run with debug enabled."""
     test_extra_info: Optional[Dict[str, str]] = None
     """Optional dict of key-value pairs that will be passed to the test executor"""
+    release_name: Optional[str] = None
+    """Name of the Helm release the chart under test was deployed as."""
+    deploy_namespace: Optional[str] = None
+    """Namespace the chart under test was deployed into."""
 
 
 class TestExecutor(ABC):
@@ -173,6 +177,12 @@ class TestExecutor(ABC):
 
         if exec_info.app_config_file_path is not None:
             env_vars["ATS_APP_CONFIG_FILE_PATH"] = exec_info.app_config_file_path
+
+        if exec_info.release_name is not None:
+            env_vars["ATS_RELEASE_NAME"] = exec_info.release_name
+
+        if exec_info.deploy_namespace is not None:
+            env_vars["ATS_RELEASE_NAMESPACE"] = exec_info.deploy_namespace
 
         if exec_info.test_extra_info:
             env_vars.update({"ATS_EXTRA_" + k.upper(): v for k, v in exec_info.test_extra_info.items()})

--- a/app_test_suite/steps/scenarios/simple.py
+++ b/app_test_suite/steps/scenarios/simple.py
@@ -2,7 +2,7 @@ import argparse
 import logging
 import os
 from abc import ABC, abstractmethod
-from typing import Optional, Set, cast
+from typing import Dict, Optional, Set, cast
 
 import configargparse
 import yaml
@@ -43,7 +43,10 @@ TEST_APP_CATALOG_NAME: str = "chartmuseum"
 TEST_APP_CATALOG_NAMESPACE: str = "default"
 CONTEXT_KEY_APP_CR: str = "app_cr"
 CONTEXT_KEY_APP_CM_CR: str = "app_cm_cr"
+CONTEXT_KEY_RELEASE_NAME: str = "release_name"
 CHART_YAML = "Chart.yaml"
+_HELM_BIN = "helm"
+_HELM_DEPLOY_TIMEOUT = "30m"
 
 logger = logging.getLogger(__name__)
 
@@ -106,6 +109,10 @@ class SimpleTestScenario(BuildStep, ABC):
             config,
             BaseTestScenariosFilteringPipeline.KEY_CONFIG_OPTION_DEPLOY_CONFIG_FILE,
         )
+        deploy_namespace = get_config_value_by_cmd_line_option(
+            config,
+            BaseTestScenariosFilteringPipeline.KEY_CONFIG_OPTION_DEPLOY_NAMESPACE,
+        )
         cluster_info = cast(ClusterInfo, self._cluster_info)
         exec_info = TestExecInfo(
             chart_path=config.chart_file,
@@ -116,6 +123,8 @@ class SimpleTestScenario(BuildStep, ABC):
             kube_config_path=os.path.abspath(cluster_info.kube_config_path),
             test_type=self.test_provided,
             debug=config.debug,
+            release_name=context.get(CONTEXT_KEY_RELEASE_NAME),
+            deploy_namespace=deploy_namespace,
         )
         self._test_executor.prepare_test_environment(exec_info)
         self._test_executor.execute_test(exec_info)
@@ -217,14 +226,12 @@ class SimpleTestScenario(BuildStep, ABC):
         except Exception:
             raise ATSTestError("Can't establish connection to the new test cluster")
 
-        # prepare app platform and upload artifacts
         if not self._cluster_info.app_platform_ready:
-            logger.debug("App Platform not initialized, running `apptestctl`")
+            logger.debug("Cluster prerequisites not initialized, running `apptestctl`")
             self._ensure_app_platform_ready(self._cluster_info.kube_config_path)
             self._cluster_info.app_platform_ready = True
         else:
-            logger.debug("App Platform already initialized, not running `apptestctl`")
-        self._upload_chart_to_app_catalog(config, config.chart_file)
+            logger.debug("Cluster prerequisites already initialized, not running `apptestctl`")
 
         try:
             if (
@@ -240,18 +247,16 @@ class SimpleTestScenario(BuildStep, ABC):
             self._collect_failure_diagnostics(config, context)
             raise ATSTestError(f"Application deployment failed: {e}")
         finally:
+            # honor --app-tests-skip-app-delete; both delete helpers no-op when nothing was deployed
             if not get_config_value_by_cmd_line_option(
-                config,
-                BaseTestScenariosFilteringPipeline.KEY_CONFIG_OPTION_SKIP_DEPLOY_APP,
-            ) or not get_config_value_by_cmd_line_option(
                 config,
                 BaseTestScenariosFilteringPipeline.KEY_CONFIG_OPTION_SKIP_DELETE_APP,
             ):
                 self._delete_app(config, context)
+                self._delete_release(config, context)
 
     def _deploy_tested_chart_as_app(self, config: argparse.Namespace, context: Context) -> None:
-        app_name = context[CONTEXT_KEY_CHART_YAML]["name"]
-        app_version = context[CONTEXT_KEY_CHART_YAML]["version"]
+        release_name = context[CONTEXT_KEY_CHART_YAML]["name"]
         deploy_namespace = get_config_value_by_cmd_line_option(
             config,
             BaseTestScenariosFilteringPipeline.KEY_CONFIG_OPTION_DEPLOY_NAMESPACE,
@@ -260,17 +265,41 @@ class SimpleTestScenario(BuildStep, ABC):
             config,
             BaseTestScenariosFilteringPipeline.KEY_CONFIG_OPTION_DEPLOY_CONFIG_FILE,
         )
+        self._helm_deploy(release_name, config.chart_file, deploy_namespace, app_config_file_path)
+        context[CONTEXT_KEY_RELEASE_NAME] = release_name
 
-        app_obj = self._deploy_chart(
-            app_name,
-            app_version,
+    def _helm_deploy(
+        self,
+        release_name: str,
+        chart_file: str,
+        deploy_namespace: str,
+        app_config_file_path: Optional[str],
+    ) -> None:
+        # Giant Swarm charts may ship PolicyException resources in the policy-exceptions namespace;
+        # ensure it exists so the install does not fail on a cluster that lacks it.
+        logger.info("Ensuring namespace 'policy-exceptions'.")
+        ensure_namespace_exists(self._kube_client, "policy-exceptions")
+
+        args = [
+            _HELM_BIN,
+            "upgrade",
+            "--install",
+            release_name,
+            chart_file,
+            "--namespace",
             deploy_namespace,
-            app_config_file_path,
-            TEST_APP_CATALOG_NAME,
-            TEST_APP_CATALOG_NAMESPACE,
-        )
-        context[CONTEXT_KEY_APP_CR] = app_obj.app
-        context[CONTEXT_KEY_APP_CM_CR] = app_obj.app_cm
+            "--create-namespace",
+            "--reset-values",
+            "--wait",
+            "--timeout",
+            _HELM_DEPLOY_TIMEOUT,
+        ]
+        if app_config_file_path:
+            args += ["--values", app_config_file_path]
+        logger.info(f"Installing chart as Helm release '{release_name}' into namespace '{deploy_namespace}'.")
+        run_res = run_and_log(args, env=self._helm_env())  # nosec, chart file is the user's responsibility
+        if run_res.returncode != 0:
+            raise ATSTestError(f"Installing Helm release '{release_name}' failed")
 
     def _deploy_chart(
         self,
@@ -455,6 +484,26 @@ class SimpleTestScenario(BuildStep, ABC):
             self._APP_DELETION_TIMEOUT_SEC,
         )
         logger.info("Application deleted")
+
+    def _delete_release(self, config: argparse.Namespace, context: Context) -> None:
+        release_name = context.get(CONTEXT_KEY_RELEASE_NAME)
+        if release_name is None:
+            return
+        deploy_namespace = get_config_value_by_cmd_line_option(
+            config,
+            BaseTestScenariosFilteringPipeline.KEY_CONFIG_OPTION_DEPLOY_NAMESPACE,
+        )
+        logger.info(f"Uninstalling Helm release '{release_name}' from namespace '{deploy_namespace}'.")
+        run_res = run_and_log(
+            [_HELM_BIN, "uninstall", release_name, "--namespace", deploy_namespace, "--wait"],
+            env=self._helm_env(),
+        )  # nosec
+        if run_res.returncode != 0:
+            logger.warning(f"Uninstalling Helm release '{release_name}' failed; continuing.")
+
+    def _helm_env(self) -> Dict[str, str]:
+        kube_config_path = cast(ClusterInfo, self._cluster_info).kube_config_path
+        return {**os.environ, "KUBECONFIG": kube_config_path}
 
 
 class FunctionalTestScenario(SimpleTestScenario):

--- a/app_test_suite/steps/scenarios/upgrade.py
+++ b/app_test_suite/steps/scenarios/upgrade.py
@@ -4,21 +4,12 @@ import logging
 import os
 import re
 import shutil
+import subprocess
 from tempfile import TemporaryDirectory
 from typing import Tuple, cast, Match, Optional, Dict
 
 import requests
 import yaml
-from pykube import ConfigMap
-from pytest_helm_charts.giantswarm_app_platform.app import (
-    delete_app,
-    wait_for_app_to_be_deleted,
-    ConfiguredApp,
-)
-from pytest_helm_charts.giantswarm_app_platform.catalog import (
-    CatalogCR,
-    make_catalog_obj,
-)
 from requests import RequestException
 from semver import VersionInfo
 from step_exec_lib.errors import ConfigError
@@ -50,15 +41,15 @@ from app_test_suite.steps.base import (
 )
 from app_test_suite.steps.scenarios.simple import (
     SimpleTestScenario,
-    TEST_APP_CATALOG_NAME,
-    TEST_APP_CATALOG_NAMESPACE,
+    CONTEXT_KEY_RELEASE_NAME,
+    _HELM_BIN,
 )
 from app_test_suite.steps.test_types import STEP_TEST_UPGRADE
 
 KEY_PRE_UPGRADE = "pre_upgrade"
 KEY_POST_UPGRADE = "post_upgrade"
 KEY_UPGRADE_TEST_STAGE_EXTRA_INFO = "upgrade_test_stage"
-STABLE_APP_CATALOG_NAME = "stable"
+_HELM_PULL_TIMEOUT_SEC = 120
 
 logger = logging.getLogger(__name__)
 
@@ -132,63 +123,57 @@ class UpgradeTestScenario(SimpleTestScenario):
                 )
         self._test_executor.validate(config, self.name)
 
-    def _prepare_stable_app(
+    def _resolve_stable_chart(
         self,
         config: argparse.Namespace,
         context: Context,
         app_name: str,
-        deploy_namespace: str,
-    ) -> Tuple[str, str, str, str, str]:
+        download_dir: str,
+    ) -> Tuple[str, str]:
+        """Resolve the stable chart to a local .tgz file and return its path and version."""
         if self._stable_from_local_file:
-            # upload file to existing catalog
             stable_chart_file_path = get_config_value_by_cmd_line_option(config, KEY_CFG_STABLE_APP_FILE)
-            self._upload_chart_to_app_catalog(config, stable_chart_file_path)
-            app_catalog_cr = CatalogCR.objects(self._kube_client).get_by_name(TEST_APP_CATALOG_NAME)
             stable_ver_match = self._semver_regex_match.fullmatch(stable_chart_file_path)
             stable_app_version = cast(Match, stable_ver_match).group(1)
             TestInfoProvider().extract_chart_info(stable_chart_file_path, CONTEXT_KEY_STABLE_CHART_YAML, context)
-            catalog_url = app_catalog_cr.obj["spec"]["storage"]["URL"]
-            chart_url = f"{catalog_url}/{app_name}-{stable_app_version}.tgz"
-            return (
-                stable_app_version,
-                TEST_APP_CATALOG_NAME,
-                TEST_APP_CATALOG_NAMESPACE,
-                catalog_url,
-                chart_url,
-            )
+            return stable_chart_file_path, stable_app_version
 
+        # `helm pull --repo` resolves against an HTTP(S) chart repository index (e.g. chartmuseum).
+        # OCI catalog URLs (oci://...) are not handled here; they would need `helm pull oci://.../<chart>`.
         catalog_url = get_config_value_by_cmd_line_option(config, KEY_CFG_STABLE_APP_URL)
-        logger.info(f"Adding new app catalog named '{STABLE_APP_CATALOG_NAME}' with URL '{catalog_url}'.")
-        catalog_cr = make_catalog_obj(self._kube_client, STABLE_APP_CATALOG_NAME, deploy_namespace, catalog_url)
-        logger.debug(f"Creating Catalog '{catalog_cr.name}' with the stable app version.")
-        catalog_cr.create()
-
         stable_chart_ver = get_config_value_by_cmd_line_option(config, KEY_CFG_STABLE_APP_VERSION)
         if stable_chart_ver == "latest":
             stable_chart_ver = self._get_latest_app_version(catalog_url, app_name)
 
-        chart_url = f"{catalog_url}/{app_name}-{stable_chart_ver}.tgz"
-        with TemporaryDirectory("-ats-download") as d:
-            try:
-                r = requests.get(chart_url, allow_redirects=True, timeout=10)
-                if not r.ok:
-                    raise ATSTestError(
-                        f"Error 'HTTP-{r.status_code}' when fetching remote chart '{chart_url}': {r.reason}"
-                    )
-            except RequestException as e:
-                logger.error(f"Error when trying to fetch remote chart '{chart_url}': '{e}'.")
-                raise
-            chart_file_name = os.path.join(d, "chart.tgz")
-            with open(chart_file_name, "wb") as f:
-                f.write(r.content)
-            TestInfoProvider().extract_chart_info(chart_file_name, CONTEXT_KEY_STABLE_CHART_YAML, context)
-        return (
-            stable_chart_ver,
-            STABLE_APP_CATALOG_NAME,
-            deploy_namespace,
-            catalog_url,
-            chart_url,
-        )
+        logger.info(f"Pulling stable chart '{app_name}' version '{stable_chart_ver}' from '{catalog_url}'.")
+        try:
+            run_res = run_and_log(
+                [
+                    _HELM_BIN,
+                    "pull",
+                    app_name,
+                    "--repo",
+                    catalog_url,
+                    "--version",
+                    stable_chart_ver,
+                    "--destination",
+                    download_dir,
+                ],
+                env=self._helm_env(),
+                timeout=_HELM_PULL_TIMEOUT_SEC,
+            )  # nosec
+        except subprocess.TimeoutExpired:
+            raise ATSTestError(
+                f"Pulling stable chart '{app_name}' version '{stable_chart_ver}' from '{catalog_url}' "
+                f"timed out after {_HELM_PULL_TIMEOUT_SEC}s"
+            )
+        if run_res.returncode != 0:
+            raise ATSTestError(
+                f"Pulling stable chart '{app_name}' version '{stable_chart_ver}' from '{catalog_url}' failed"
+            )
+        stable_chart_file_path = os.path.join(download_dir, f"{app_name}-{stable_chart_ver}.tgz")
+        TestInfoProvider().extract_chart_info(stable_chart_file_path, CONTEXT_KEY_STABLE_CHART_YAML, context)
+        return stable_chart_file_path, stable_chart_ver
 
     def run_tests(self, config: argparse.Namespace, context: Context) -> None:
         app_name = context[CONTEXT_KEY_CHART_YAML]["name"]
@@ -198,82 +183,53 @@ class UpgradeTestScenario(SimpleTestScenario):
             config,
             BaseTestScenariosFilteringPipeline.KEY_CONFIG_OPTION_DEPLOY_NAMESPACE,
         )
-        app_cfg_file = get_config_value_by_cmd_line_option(config, KEY_CFG_STABLE_APP_CONFIG)
-
-        (
-            stable_chart_ver,
-            stable_app_catalog_name,
-            stable_app_catalog_namespace,
-            stable_app_catalog_url,
-            stable_chart_url,
-        ) = self._prepare_stable_app(config, context, app_name, deploy_namespace)
-        if VersionInfo.parse(stable_chart_ver) >= VersionInfo.parse(chart_version):
-            logger.warning(
-                "You have requested upgrade test where the stable chart version seems to be "
-                "newer then (or the same as) the version under test. Stable version is "
-                f"'{stable_chart_ver}', under test '{chart_version}'."
-            )
-
-        # deploy the stable version
-        stable_app = self._deploy_chart(
-            app_name,
-            stable_chart_ver,
-            deploy_namespace,
-            app_cfg_file,
-            stable_app_catalog_name,
-            stable_app_catalog_namespace,
-        )
-
-        # run tests
-        exec_info = self._get_test_exec_info(
-            stable_chart_url,
-            stable_chart_ver,
-            app_cfg_file,
-            config,
-            test_extra_info={KEY_UPGRADE_TEST_STAGE_EXTRA_INFO: KEY_PRE_UPGRADE},
-        )
-        self._test_executor.prepare_test_environment(exec_info)
-        self._test_executor.execute_test(exec_info)
-
-        # run the optional upgrade hook
-        self._run_upgrade_hook(config, KEY_PRE_UPGRADE, app_name, stable_chart_ver, chart_version)
-
-        # reconfigure App CR to point to the new version UT
+        stable_app_cfg_file = get_config_value_by_cmd_line_option(config, KEY_CFG_STABLE_APP_CONFIG)
         app_config_file_path = get_config_value_by_cmd_line_option(
             config,
             BaseTestScenariosFilteringPipeline.KEY_CONFIG_OPTION_DEPLOY_CONFIG_FILE,
         )
-        self._upgrade_app_cr(stable_app, chart_version, app_config_file_path)
 
-        # run the optional upgrade hook
-        self._run_upgrade_hook(config, KEY_POST_UPGRADE, app_name, stable_chart_ver, chart_version)
+        with TemporaryDirectory("-ats-stable-chart") as stable_dir:
+            stable_chart_file, stable_chart_ver = self._resolve_stable_chart(config, context, app_name, stable_dir)
+            if VersionInfo.parse(stable_chart_ver) >= VersionInfo.parse(chart_version):
+                logger.warning(
+                    "You have requested upgrade test where the stable chart version seems to be "
+                    "newer then (or the same as) the version under test. Stable version is "
+                    f"'{stable_chart_ver}', under test '{chart_version}'."
+                )
 
-        # run tests again
-        exec_info.chart_path = config.chart_file
-        exec_info.chart_ver = chart_version
-        exec_info.app_config_file_path = app_config_file_path
-        cast(Dict[str, str], exec_info.test_extra_info)[KEY_UPGRADE_TEST_STAGE_EXTRA_INFO] = KEY_POST_UPGRADE
-        self._test_executor.execute_test(exec_info)
+            # deploy the stable version
+            self._helm_deploy(app_name, stable_chart_file, deploy_namespace, stable_app_cfg_file)
+            context[CONTEXT_KEY_RELEASE_NAME] = app_name
 
-        # delete App CR
-        logger.info(f"Deleting App CR '{stable_app.app.name}'.")
-        delete_app(stable_app)
-        wait_for_app_to_be_deleted(
-            self._kube_client,
-            stable_app.app.name,
-            stable_app.app.namespace,
-            self._APP_DELETION_TIMEOUT_SEC,
-        )
+            # run pre-upgrade tests
+            exec_info = self._get_test_exec_info(
+                stable_chart_file,
+                stable_chart_ver,
+                stable_app_cfg_file,
+                config,
+                release_name=app_name,
+                deploy_namespace=deploy_namespace,
+                test_extra_info={KEY_UPGRADE_TEST_STAGE_EXTRA_INFO: KEY_PRE_UPGRADE},
+            )
+            self._test_executor.prepare_test_environment(exec_info)
+            self._test_executor.execute_test(exec_info)
 
-        # delete Catalog CR, if it was created
-        catalog_cr = (
-            CatalogCR.objects(self._kube_client)
-            .filter(namespace=deploy_namespace)
-            .get_or_none(name=STABLE_APP_CATALOG_NAME)
-        )
-        if catalog_cr:
-            logger.debug(f"Deleting Catalog '{catalog_cr.name}'.")
-            catalog_cr.delete()
+            # run the optional pre-upgrade hook
+            self._run_upgrade_hook(config, KEY_PRE_UPGRADE, app_name, stable_chart_ver, chart_version)
+
+            # upgrade to the version under test
+            self._helm_deploy(app_name, config.chart_file, deploy_namespace, app_config_file_path)
+
+            # run the optional post-upgrade hook
+            self._run_upgrade_hook(config, KEY_POST_UPGRADE, app_name, stable_chart_ver, chart_version)
+
+            # run tests again against the upgraded release
+            exec_info.chart_path = config.chart_file
+            exec_info.chart_ver = chart_version
+            exec_info.app_config_file_path = app_config_file_path
+            cast(Dict[str, str], exec_info.test_extra_info)[KEY_UPGRADE_TEST_STAGE_EXTRA_INFO] = KEY_POST_UPGRADE
+            self._test_executor.execute_test(exec_info)
 
         # save metadata, if requested
         if get_config_value_by_cmd_line_option(config, KEY_CFG_UPGRADE_SAVE_METADATA):
@@ -286,78 +242,6 @@ class UpgradeTestScenario(SimpleTestScenario):
                 exec_info.cluster_type,
                 exec_info.cluster_version,
             )
-
-    def _upgrade_app_cr(
-        self,
-        configured_app: ConfiguredApp,
-        app_version: str,
-        app_config_file_path: Optional[str],
-    ) -> ConfiguredApp:
-        """
-        Upgrade deployed stable version to the Under-Test version:
-
-        Args:
-             configured_app: App CR of the deployed stable version
-             app_version: version to upgrade to
-             app_config_file_path: configuration file for the deployment of the version to upgrade to
-        """
-
-        # prepare new values for app and app_cm
-        app = configured_app.app
-        app_cm: Optional[ConfigMap] = None
-        # update chart reference
-        app.reload()
-        app.obj["spec"]["catalog"] = TEST_APP_CATALOG_NAME
-        app.obj["spec"]["catalogNamespace"] = TEST_APP_CATALOG_NAMESPACE
-        app.obj["spec"]["version"] = app_version
-
-        # if there's a new config file, let's load it
-        if app_config_file_path:
-            with open(app_config_file_path) as f:
-                config_values_raw = f.read()
-                new_config_values = yaml.dump(yaml.safe_load(config_values_raw))
-
-        # if the stable app used no config file, but the under-test version uses one
-        # we have to created the CM and update App CR to reference it
-        if not configured_app.app_cm and app_config_file_path:
-            logger.debug("Detected that the stable app didn't use a ConfigMap, but the new one does. Creating CM.")
-            # TODO: extract this to pytest-helm-charts to create Apps' CMs
-            app_name = app.obj["spec"]["name"]
-            app_namespace = app.obj["spec"]["namespace"]
-            app_cm_name = f"{app_name}-testing-user-config"
-            app_cm_data = {
-                "apiVersion": "v1",
-                "kind": "ConfigMap",
-                "metadata": {"name": app_cm_name, "namespace": app_namespace},
-                "data": {"values": new_config_values},
-            }
-            app_cm = ConfigMap(self._kube_client, app_cm_data)
-            app_cm.create()
-            app.obj["spec"]["config"] = {"configMap": {"name": app_cm_name, "namespace": app_namespace}}
-
-        # if the stable app used a config file, but the under-test version doesn't use one
-        # we have to delete the CM, remove the reference in App CR and update our app data structure
-        if configured_app.app_cm and not app_config_file_path:
-            logger.debug("Detected that the stable app used a ConfigMap, but the new one doesn't. Deleting CM.")
-            del configured_app.app.obj["spec"]["config"]
-            configured_app.app_cm.reload()
-            configured_app.app_cm.delete()
-
-        # if both the stable and under-test app versions used a config file, we just have to update the values
-        if configured_app.app_cm is not None and app_config_file_path:
-            app_cm = configured_app.app_cm
-            app_cm.reload()
-            if app_cm.obj["data"]["values"] != new_config_values:
-                logger.debug("Detected that both old and new app versions use a ConfigMap. Updating CM.")
-                app_cm.obj["data"]["values"] = new_config_values
-                app_cm.update()
-            else:
-                logger.debug("Detected that both old and new app versions use the same ConfigMap. No CM update needed.")
-
-        # finally, update the App CR
-        logger.info("Updating App CR to point to the newer version.")
-        app.update()
-        return ConfiguredApp(app, app_cm)
 
     def _get_latest_app_version(self, stable_app_catalog_url: str, app_name: str) -> str:
         logger.info("Trying to detect latest app version available in the catalog.")
@@ -439,6 +323,8 @@ class UpgradeTestScenario(SimpleTestScenario):
         chart_ver: str,
         chart_config_file: str,
         config: argparse.Namespace,
+        release_name: Optional[str] = None,
+        deploy_namespace: Optional[str] = None,
         test_extra_info: Optional[Dict[str, str]] = None,
     ) -> TestExecInfo:
         cluster_info = cast(ClusterInfo, self._cluster_info)
@@ -451,6 +337,8 @@ class UpgradeTestScenario(SimpleTestScenario):
             kube_config_path=os.path.abspath(cluster_info.kube_config_path),
             test_type=self.test_provided,
             debug=config.debug,
+            release_name=release_name,
+            deploy_namespace=deploy_namespace,
             test_extra_info=test_extra_info,
         )
         return exec_info

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -2,25 +2,21 @@ import os
 import shutil
 import unittest
 import unittest.mock
-from types import ModuleType
-from typing import cast, Tuple, Any
+from typing import cast
+from unittest.mock import Mock
 
 import pykube
 import yaml
 from configargparse import Namespace
-from pytest_helm_charts.giantswarm_app_platform.app import ConfiguredApp
 from pytest_mock import MockerFixture
-from requests import Response
 
 import app_test_suite
 from app_test_suite.cluster_manager import ClusterManager
 from app_test_suite.cluster_providers import ExternalClusterProvider
 from app_test_suite.cluster_providers.cluster_provider import ClusterInfo, ClusterType
-from app_test_suite.steps.scenarios.simple import SimpleTestScenario
-from app_test_suite.steps.scenarios.upgrade import STABLE_APP_CATALOG_NAME
+from app_test_suite.steps.scenarios.simple import _HELM_BIN, _HELM_DEPLOY_TIMEOUT
 
 MOCK_UPGRADE_CATALOG_URL = "http://chartmuseum.giantswarm:8080/charts/"
-MOCK_STABLE_APP_CATALOG_NAMESPACE = "default"
 MOCK_KUBE_CONFIG_PATH = "/nonexisting-flsdhge235/kube.config"
 MOCK_KUBE_VERSION = "1.19.1"
 MOCK_APP_NAME = "mock_app"
@@ -32,64 +28,52 @@ MOCK_CHART_FILE_NAME = f"{MOCK_APP_NAME}-{MOCK_CHART_VERSION}.tgz"
 MOCK_UPGRADE_UPGRADE_HOOK = "mock.sh"
 MOCK_UPGRADE_APP_CONFIG_FILE = ""
 MOCK_UPGRADE_APP_VERSION = "0.2.4-1"
-MOCK_UPGRADE_CHART_FILE_URL = f"{MOCK_UPGRADE_CATALOG_URL}/{MOCK_APP_NAME}-{MOCK_UPGRADE_APP_VERSION}.tgz"
+MOCK_STABLE_APP_FILE = f"examples/apps/hello-world-app/hello-world-app-{MOCK_UPGRADE_APP_VERSION}.tgz"
 UPGRADE_META_FILE_NAME = f"tested-upgrade-{MOCK_CHART_VERSION}.yaml"
 
 
-def assert_runner_deletes_app(runner: ModuleType, configured_app_mock: ConfiguredApp) -> None:
-    cast(unittest.mock.Mock, runner.delete_app).assert_called_once_with(configured_app_mock)  # type: ignore
-    # noinspection PyProtectedMember
-    cast(unittest.mock.Mock, runner.wait_for_app_to_be_deleted).assert_called_once_with(  # type: ignore
-        unittest.mock.ANY,
-        configured_app_mock.app.name,
-        configured_app_mock.app.namespace,
-        SimpleTestScenario._APP_DELETION_TIMEOUT_SEC,
-    )
+def _helm_deploy_args(release_name: str, chart_file: str, deploy_namespace: str, values_file: str = "") -> list:
+    args = [
+        _HELM_BIN,
+        "upgrade",
+        "--install",
+        release_name,
+        chart_file,
+        "--namespace",
+        deploy_namespace,
+        "--create-namespace",
+        "--reset-values",
+        "--wait",
+        "--timeout",
+        _HELM_DEPLOY_TIMEOUT,
+    ]
+    if values_file:
+        args += ["--values", values_file]
+    return args
 
 
-def assert_base_tester_deletes_app(configured_app_mock: ConfiguredApp) -> None:
-    assert_runner_deletes_app(app_test_suite.steps.scenarios.simple, configured_app_mock)
-
-
-def assert_upgrade_tester_deletes_app(configured_app_mock: ConfiguredApp) -> None:
-    assert_runner_deletes_app(app_test_suite.steps.scenarios.upgrade, configured_app_mock)
-
-
-def assert_deploy_and_wait_for_app_cr(
-    app_name: str,
-    app_version: str,
-    app_deploy_ns: str,
-    catalog_name: str,
-    catalog_namespace: str,
+def assert_helm_deployed(
+    release_name: str,
+    chart_file: str,
+    deploy_namespace: str,
+    kube_config_path: str,
+    values_file: str = "",
 ) -> None:
-    cast(unittest.mock.Mock, app_test_suite.steps.scenarios.simple.create_app).assert_called_once_with(
-        unittest.mock.ANY,
-        app_name,
-        app_version,
-        catalog_name,
-        catalog_namespace,
-        app_deploy_ns,
-        app_deploy_ns,
-        None,
-    )
-    # noinspection PyProtectedMember
-    cast(unittest.mock.Mock, app_test_suite.steps.scenarios.simple.wait_for_apps_to_run).assert_called_once_with(
-        unittest.mock.ANY,
-        [app_name],
-        app_deploy_ns,
-        SimpleTestScenario._APP_DEPLOYMENT_TIMEOUT_SEC,
+    cast(Mock, app_test_suite.steps.scenarios.simple.run_and_log).assert_any_call(
+        _helm_deploy_args(release_name, chart_file, deploy_namespace, values_file),
+        env={"KUBECONFIG": kube_config_path},
     )
 
 
-def assert_chart_file_uploaded(config: Namespace, chart_file_name: str) -> None:
-    cast(
-        unittest.mock.Mock,
-        app_test_suite.steps.scenarios.simple.ChartMuseumAppRepository.upload_artifact,
-    ).assert_called_once_with(config, chart_file_name)
+def assert_helm_uninstalled(release_name: str, deploy_namespace: str, kube_config_path: str) -> None:
+    cast(Mock, app_test_suite.steps.scenarios.simple.run_and_log).assert_any_call(
+        [_HELM_BIN, "uninstall", release_name, "--namespace", deploy_namespace, "--wait"],
+        env={"KUBECONFIG": kube_config_path},
+    )
 
 
 def assert_app_platform_ready(kube_config_path: str) -> None:
-    cast(unittest.mock.Mock, app_test_suite.steps.scenarios.simple.run_and_log).assert_called_with(
+    cast(unittest.mock.Mock, app_test_suite.steps.scenarios.simple.run_and_log).assert_any_call(
         ["apptestctl", "bootstrap", f"--kubeconfig-path={kube_config_path}", "--wait"]
     )
 
@@ -102,6 +86,7 @@ def assert_cluster_connection_created(kube_config_path: str) -> None:
 def get_base_config(mocker: MockerFixture) -> Namespace:
     config = mocker.Mock(name="ConfigMock")
     config.app_tests_skip_app_deploy = False
+    config.app_tests_skip_app_delete = False
     config.app_tests_deploy_namespace = MOCK_APP_DEPLOY_NS
     config.app_tests_app_config_file = ""
     config.chart_file = MOCK_CHART_FILE_NAME
@@ -122,7 +107,7 @@ def patch_base_test_runner(
     run_and_log_res: unittest.mock.Mock,
     app_name: str,
     app_namespace: str,
-) -> ConfiguredApp:
+) -> None:
     mocker.patch.dict(os.environ, {}, clear=True)
     mocker.patch("pykube.KubeConfig.from_file", name="MockKubeConfig")
     mocker.patch("app_test_suite.steps.scenarios.simple.HTTPClient")
@@ -130,19 +115,7 @@ def patch_base_test_runner(
         "app_test_suite.steps.scenarios.simple.run_and_log",
         return_value=run_and_log_res,
     )
-    mocker.patch("app_test_suite.steps.scenarios.simple.ChartMuseumAppRepository.upload_artifact")
-    app_cr = mocker.MagicMock(name="appCR")
-    app_cr.name = app_name
-    app_cr.namespace = app_namespace
-    configured_app_mock = ConfiguredApp(app_cr, mocker.MagicMock(name="appCM"))
-    mocker.patch(
-        "app_test_suite.steps.scenarios.simple.create_app",
-        return_value=configured_app_mock,
-    )
-    mocker.patch("app_test_suite.steps.scenarios.simple.wait_for_apps_to_run")
-    mocker.patch("app_test_suite.steps.scenarios.simple.delete_app")
-    mocker.patch("app_test_suite.steps.scenarios.simple.wait_for_app_to_be_deleted")
-    return configured_app_mock
+    mocker.patch("app_test_suite.steps.scenarios.simple.ensure_namespace_exists")
 
 
 def get_mock_cluster_manager(mocker: MockerFixture) -> ClusterManager:
@@ -160,8 +133,9 @@ def get_mock_cluster_manager(mocker: MockerFixture) -> ClusterManager:
 
 
 def configure_for_upgrade_test(config: Namespace) -> None:
-    config.upgrade_tests_app_catalog_url = MOCK_UPGRADE_CATALOG_URL
-    config.upgrade_tests_app_version = MOCK_UPGRADE_APP_VERSION
+    config.upgrade_tests_app_catalog_url = ""
+    config.upgrade_tests_app_file = MOCK_STABLE_APP_FILE
+    config.upgrade_tests_app_version = ""
     config.upgrade_tests_app_config_file = MOCK_UPGRADE_APP_CONFIG_FILE
     config.upgrade_tests_upgrade_hook = MOCK_UPGRADE_UPGRADE_HOOK
     config.upgrade_tests_save_metadata = True
@@ -171,40 +145,11 @@ def configure_for_upgrade_test(config: Namespace) -> None:
     config.app_tests_skip_app_deploy = True
 
 
-def patch_upgrade_test_runner(
-    mocker: MockerFixture, run_and_log_call_result_mock: unittest.mock.Mock
-) -> Tuple[unittest.mock.Mock, unittest.mock.Mock]:
-    mock_stable_app_catalog_cr = mocker.MagicMock(name="stable CatalogCR Mock")
-    mocker.patch(
-        "app_test_suite.steps.scenarios.upgrade.make_catalog_obj",
-        return_value=mock_stable_app_catalog_cr,
-    )
+def patch_upgrade_test_runner(mocker: MockerFixture, run_and_log_call_result_mock: unittest.mock.Mock) -> None:
     mocker.patch(
         "app_test_suite.steps.scenarios.upgrade.run_and_log",
         return_value=run_and_log_call_result_mock,
     )
-
-    def get_or_none(*_: Any, **kwargs: str) -> None:
-        res = mock_stable_app_catalog_cr if kwargs["name"] == STABLE_APP_CATALOG_NAME else mock_app_catalog_cr
-        return res
-
-    mock_app_catalog_cr = mocker.MagicMock(name="CatalogCR mock")
-    app_catalog_cr_objects_res = mocker.MagicMock(name="CatalogCR.objects() result")
-    filter_result = mocker.MagicMock(name="CatalogCR.objects().filter() result")
-    filter_result.get_or_none.side_effect = get_or_none
-    app_catalog_cr_objects_res.filter.return_value = filter_result
-    mocker.patch(
-        "app_test_suite.steps.scenarios.upgrade.CatalogCR.objects",
-        return_value=app_catalog_cr_objects_res,
-    )
-    mocker.patch("app_test_suite.steps.scenarios.upgrade.delete_app")
-    mocker.patch("app_test_suite.steps.scenarios.upgrade.wait_for_app_to_be_deleted")
-    return mock_app_catalog_cr, mock_stable_app_catalog_cr
-
-
-def assert_app_updated(configured_app_mock: ConfiguredApp) -> None:
-    cast(unittest.mock.Mock, configured_app_mock.app.reload).assert_called_once()
-    cast(unittest.mock.Mock, configured_app_mock.app.update).assert_called_once()
 
 
 def assert_upgrade_tester_exec_hook(
@@ -226,20 +171,6 @@ def assert_upgrade_tester_exec_hook(
             deploy_namespace,
         ],
     )
-
-
-def patch_requests_get_chart(mocker: MockerFixture) -> unittest.mock.Mock:
-    requests_get_res = mocker.MagicMock(spec=Response, name="chart get result")
-    requests_get_res.ok = True
-    requests_get_res.status_code = 200
-    with open("examples/apps/hello-world-app/hello-world-app-0.2.4-1.tgz", "rb") as f:
-        chart_content = f.read()
-    requests_get_res.content = chart_content
-    mocker.patch(
-        "app_test_suite.steps.scenarios.upgrade.requests.get",
-        return_value=requests_get_res,
-    )
-    return cast(unittest.mock.Mock, app_test_suite.steps.scenarios.upgrade.requests.get)
 
 
 def assert_upgrade_metadata_created() -> None:

--- a/tests/scenarios/executors/gotest.py
+++ b/tests/scenarios/executors/gotest.py
@@ -7,7 +7,7 @@ from step_exec_lib.types import StepType
 
 import app_test_suite
 import app_test_suite.steps.executors.gotest
-from tests.helpers import MOCK_KUBE_VERSION
+from tests.helpers import MOCK_KUBE_VERSION, MOCK_APP_NAME, MOCK_APP_DEPLOY_NS
 
 
 def assert_run_gotest(
@@ -33,6 +33,8 @@ def assert_run_gotest(
     # These are set after os.environ in get_test_info_env_variables, so they override system env
     env_vars["KUBECONFIG"] = kube_config_path
     env_vars["ATS_APP_CONFIG_FILE_PATH"] = ""
+    env_vars["ATS_RELEASE_NAME"] = MOCK_APP_NAME
+    env_vars["ATS_RELEASE_NAMESPACE"] = MOCK_APP_DEPLOY_NS
 
     if test_extra_info:
         env_vars.update({k.upper(): v for k, v in [p.split("=") for p in test_extra_info.split(",")]})

--- a/tests/scenarios/executors/pytest.py
+++ b/tests/scenarios/executors/pytest.py
@@ -7,7 +7,7 @@ from step_exec_lib.types import StepType
 
 import app_test_suite
 import app_test_suite.steps.executors.pytest
-from tests.helpers import MOCK_KUBE_VERSION
+from tests.helpers import MOCK_KUBE_VERSION, MOCK_APP_NAME, MOCK_APP_DEPLOY_NS
 
 
 def assert_run_pytest(
@@ -28,6 +28,8 @@ def assert_run_pytest(
     # These are set after os.environ in get_test_info_env_variables, so they override system env
     env_vars["KUBECONFIG"] = kube_config_path
     env_vars["ATS_APP_CONFIG_FILE_PATH"] = ""
+    env_vars["ATS_RELEASE_NAME"] = MOCK_APP_NAME
+    env_vars["ATS_RELEASE_NAMESPACE"] = MOCK_APP_DEPLOY_NS
 
     expected_args = [
         "uv",

--- a/tests/scenarios/test_simple_scenarios.py
+++ b/tests/scenarios/test_simple_scenarios.py
@@ -12,12 +12,10 @@ from app_test_suite.steps.scenarios.simple import SimpleTestScenario
 from app_test_suite.steps.scenarios.simple import (
     SmokeTestScenario,
     FunctionalTestScenario,
-    TEST_APP_CATALOG_NAME,
-    TEST_APP_CATALOG_NAMESPACE,
 )
 from tests.helpers import (
-    assert_deploy_and_wait_for_app_cr,
-    assert_chart_file_uploaded,
+    assert_helm_deployed,
+    assert_helm_uninstalled,
     assert_app_platform_ready,
     assert_cluster_connection_created,
     get_base_config,
@@ -28,9 +26,7 @@ from tests.helpers import (
     MOCK_APP_NS,
     MOCK_CHART_VERSION,
     MOCK_KUBE_CONFIG_PATH,
-    MOCK_CHART_FILE_NAME,
     MOCK_APP_DEPLOY_NS,
-    assert_base_tester_deletes_app,
 )
 from tests.scenarios.executors.gotest import patch_gotest_test_runner, assert_run_gotest
 from tests.scenarios.executors.pytest import (
@@ -84,7 +80,7 @@ def test_simple_runner_run(
     mock_cluster_manager = get_mock_cluster_manager(mocker)
     run_and_log_call_result_mock = get_run_and_log_result_mock(mocker)
 
-    configured_app_mock = patch_base_test_runner(mocker, run_and_log_call_result_mock, MOCK_APP_NAME, MOCK_APP_NS)
+    patch_base_test_runner(mocker, run_and_log_call_result_mock, MOCK_APP_NAME, MOCK_APP_NS)
     patcher(mocker, run_and_log_call_result_mock)
 
     config = get_base_config(mocker)
@@ -94,18 +90,11 @@ def test_simple_runner_run(
 
     assert_cluster_connection_created(MOCK_KUBE_CONFIG_PATH)
     assert_app_platform_ready(MOCK_KUBE_CONFIG_PATH)
-    assert_chart_file_uploaded(config, MOCK_CHART_FILE_NAME)
-    assert_deploy_and_wait_for_app_cr(
-        MOCK_APP_NAME,
-        MOCK_CHART_VERSION,
-        MOCK_APP_DEPLOY_NS,
-        TEST_APP_CATALOG_NAME,
-        TEST_APP_CATALOG_NAMESPACE,
-    )
+    assert_helm_deployed(MOCK_APP_NAME, config.chart_file, MOCK_APP_DEPLOY_NS, MOCK_KUBE_CONFIG_PATH)
     asserter(
         runner.test_provided,
         MOCK_KUBE_CONFIG_PATH,
         config.chart_file,
         MOCK_CHART_VERSION,
     )
-    assert_base_tester_deletes_app(configured_app_mock)
+    assert_helm_uninstalled(MOCK_APP_NAME, MOCK_APP_DEPLOY_NS, MOCK_KUBE_CONFIG_PATH)

--- a/tests/scenarios/test_upgrade_scenario.py
+++ b/tests/scenarios/test_upgrade_scenario.py
@@ -1,11 +1,9 @@
+import subprocess
 import unittest
-from enum import Enum
 from typing import cast, Callable
 from unittest.mock import Mock
 
 import pytest
-from pytest_helm_charts.giantswarm_app_platform.app import create_app
-from pytest_helm_charts.utils import YamlDict
 from pytest_mock import MockerFixture
 from requests import Response
 from semver import VersionInfo
@@ -20,15 +18,12 @@ from app_test_suite.steps.base import CONTEXT_KEY_CHART_YAML
 from app_test_suite.steps.base import TestExecutor
 from app_test_suite.steps.executors.gotest import GotestExecutor
 from app_test_suite.steps.executors.pytest import PytestExecutor
-from app_test_suite.steps.scenarios.simple import (
-    TEST_APP_CATALOG_NAME,
-    TEST_APP_CATALOG_NAMESPACE,
-)
 from app_test_suite.steps.scenarios.upgrade import (
     UpgradeTestScenario,
-    STABLE_APP_CATALOG_NAME,
     KEY_PRE_UPGRADE,
     KEY_POST_UPGRADE,
+    _HELM_BIN,
+    _HELM_PULL_TIMEOUT_SEC,
 )
 from tests.helpers import (
     get_mock_cluster_manager,
@@ -43,19 +38,16 @@ from tests.helpers import (
     assert_cluster_connection_created,
     MOCK_KUBE_CONFIG_PATH,
     assert_app_platform_ready,
-    assert_chart_file_uploaded,
+    assert_helm_deployed,
+    assert_helm_uninstalled,
     MOCK_CHART_FILE_NAME,
-    assert_deploy_and_wait_for_app_cr,
     MOCK_UPGRADE_APP_VERSION,
+    MOCK_UPGRADE_CATALOG_URL,
     MOCK_APP_DEPLOY_NS,
-    MOCK_UPGRADE_CHART_FILE_URL,
+    MOCK_STABLE_APP_FILE,
     assert_upgrade_tester_exec_hook,
-    assert_app_updated,
-    assert_upgrade_tester_deletes_app,
     MOCK_APP_VERSION,
-    patch_requests_get_chart,
     assert_upgrade_metadata_created,
-    MOCK_STABLE_APP_CATALOG_NAMESPACE,
 )
 from tests.scenarios.executors.gotest import assert_run_gotest, patch_gotest_test_runner
 from tests.scenarios.executors.pytest import (
@@ -189,10 +181,9 @@ def test_upgrade_pytest_runner_run(
     mock_cluster_manager = get_mock_cluster_manager(mocker)
     run_and_log_call_result_mock = get_run_and_log_result_mock(mocker)
 
-    configured_app_mock = patch_base_test_runner(mocker, run_and_log_call_result_mock, MOCK_APP_NAME, MOCK_APP_NS)
+    patch_base_test_runner(mocker, run_and_log_call_result_mock, MOCK_APP_NAME, MOCK_APP_NS)
     patcher(mocker, run_and_log_call_result_mock)
-    mock_app_catalog_cr, mock_stable_app_catalog_cr = patch_upgrade_test_runner(mocker, run_and_log_call_result_mock)
-    mock_requests_get_chart = patch_requests_get_chart(mocker)
+    patch_upgrade_test_runner(mocker, run_and_log_call_result_mock)
 
     config = get_base_config(mocker)
     configure_for_upgrade_test(config)
@@ -205,24 +196,18 @@ def test_upgrade_pytest_runner_run(
         }
     }
     runner = UpgradeTestScenario(mock_cluster_manager, test_executor)
+    runner._stable_from_local_file = True
     runner.run(config, context)
 
     assert_cluster_connection_created(MOCK_KUBE_CONFIG_PATH)
     assert_app_platform_ready(MOCK_KUBE_CONFIG_PATH)
-    assert_chart_file_uploaded(config, MOCK_CHART_FILE_NAME)
-    assert_deploy_and_wait_for_app_cr(
-        MOCK_APP_NAME,
-        MOCK_UPGRADE_APP_VERSION,
-        MOCK_APP_DEPLOY_NS,
-        STABLE_APP_CATALOG_NAME,
-        MOCK_APP_DEPLOY_NS,
-    )
+    # stable version installed via helm
+    assert_helm_deployed(MOCK_APP_NAME, MOCK_STABLE_APP_FILE, MOCK_APP_DEPLOY_NS, MOCK_KUBE_CONFIG_PATH)
     asserter_prepare()
-    mock_stable_app_catalog_cr.create.assert_any_call()
     asserter_test(
         runner.test_provided,
         MOCK_KUBE_CONFIG_PATH,
-        MOCK_UPGRADE_CHART_FILE_URL,
+        MOCK_STABLE_APP_FILE,
         MOCK_UPGRADE_APP_VERSION,
         "ats_extra_upgrade_test_stage=pre_upgrade",
     )
@@ -234,7 +219,8 @@ def test_upgrade_pytest_runner_run(
         MOCK_KUBE_CONFIG_PATH,
         MOCK_APP_DEPLOY_NS,
     )
-    assert_app_updated(configured_app_mock)
+    # under-test version installed via helm upgrade
+    assert_helm_deployed(MOCK_APP_NAME, MOCK_CHART_FILE_NAME, MOCK_APP_DEPLOY_NS, MOCK_KUBE_CONFIG_PATH)
     assert_upgrade_tester_exec_hook(
         KEY_POST_UPGRADE,
         MOCK_APP_NAME,
@@ -250,116 +236,74 @@ def test_upgrade_pytest_runner_run(
         MOCK_CHART_VERSION,
         "ats_extra_upgrade_test_stage=post_upgrade",
     )
-    mock_requests_get_chart.assert_called_once_with(MOCK_UPGRADE_CHART_FILE_URL, allow_redirects=True, timeout=10)
-    assert_upgrade_tester_deletes_app(configured_app_mock)
-    mock_stable_app_catalog_cr.delete.assert_called_once()
+    assert_helm_uninstalled(MOCK_APP_NAME, MOCK_APP_DEPLOY_NS, MOCK_KUBE_CONFIG_PATH)
     assert_upgrade_metadata_created()
 
 
-def test_upgrade_app_cr_no_configs(mocker: MockerFixture) -> None:
-    mocker.patch("pytest_helm_charts.giantswarm_app_platform.app.AppCR.create")
-    mocker.patch("pytest_helm_charts.giantswarm_app_platform.app.ConfigMap.create")
-    configured_app = create_app(
-        mocker.MagicMock(),
-        MOCK_APP_NAME,
-        MOCK_APP_VERSION,
-        STABLE_APP_CATALOG_NAME,
-        MOCK_STABLE_APP_CATALOG_NAMESPACE,
-        MOCK_APP_DEPLOY_NS,
-        MOCK_APP_DEPLOY_NS,
+def _make_remote_upgrade_runner(mocker: MockerFixture) -> UpgradeTestScenario:
+    runner = UpgradeTestScenario(get_mock_cluster_manager(mocker), PytestExecutor())
+    cluster_info = mocker.MagicMock(name="ClusterInfo")
+    cluster_info.kube_config_path = MOCK_KUBE_CONFIG_PATH
+    runner._cluster_info = cluster_info
+    runner._stable_from_local_file = False
+    return runner
+
+
+def _remote_upgrade_config(mocker: MockerFixture) -> Mock:
+    config = mocker.Mock(name="ConfigMock")
+    config.upgrade_tests_app_catalog_url = MOCK_UPGRADE_CATALOG_URL
+    config.upgrade_tests_app_version = MOCK_UPGRADE_APP_VERSION
+    return config
+
+
+def test_resolve_stable_chart_remote_pulls_with_helm(mocker: MockerFixture) -> None:
+    mocker.patch(
+        "app_test_suite.steps.scenarios.upgrade.run_and_log",
+        return_value=get_run_and_log_result_mock(mocker),
     )
-    mocker.patch.object(configured_app.app, "reload")
-    mocker.patch.object(configured_app.app, "update")
+    mocker.patch("app_test_suite.steps.scenarios.upgrade.TestInfoProvider")
+    runner = _make_remote_upgrade_runner(mocker)
 
-    runner = UpgradeTestScenario(mocker.MagicMock(), PytestExecutor())
-    new_configured_app = runner._upgrade_app_cr(configured_app, MOCK_UPGRADE_APP_VERSION, app_config_file_path="")
-
-    # both versions used no config, so there should be no change in object references
-    assert new_configured_app == configured_app
-    assert new_configured_app.app.obj["spec"]["version"] == MOCK_UPGRADE_APP_VERSION
-    assert new_configured_app.app.obj["spec"]["catalog"] == TEST_APP_CATALOG_NAME
-    assert new_configured_app.app.obj["spec"]["catalogNamespace"] == TEST_APP_CATALOG_NAMESPACE
-
-
-class ExpectedAction(Enum):
-    NO_CHANGE = 1
-    CM_DELETED = 2
-    CM_CREATED = 3
-    CM_UPDATED = 4
-
-
-@pytest.mark.parametrize(
-    "stable_config,under_test_config_file,expected_action",
-    [
-        (None, "", ExpectedAction.NO_CHANGE),
-        ({"test1": "val1"}, "", ExpectedAction.CM_DELETED),
-        (None, "tests/assets/mock_config.yaml", ExpectedAction.CM_CREATED),
-        ({"test1": "val1"}, "tests/assets/mock_config.yaml", ExpectedAction.NO_CHANGE),
-        ({"test1": "val2"}, "tests/assets/mock_config.yaml", ExpectedAction.CM_UPDATED),
-    ],
-    ids=[
-        "both no config",
-        "only stable has config",
-        "only under-test has config",
-        "both use config - no change",
-        "both use config - with change",
-    ],
-)
-def test_upgrade_app_cr_stable_has_config(
-    stable_config: YamlDict,
-    under_test_config_file: str,
-    expected_action: ExpectedAction,
-    mocker: MockerFixture,
-) -> None:
-    mocker.patch("pytest_helm_charts.giantswarm_app_platform.app.AppCR.create")
-    mocker.patch("pytest_helm_charts.giantswarm_app_platform.app.ConfigMap.create")
-    configured_app = create_app(
-        mocker.MagicMock(),
-        MOCK_APP_NAME,
-        MOCK_APP_VERSION,
-        STABLE_APP_CATALOG_NAME,
-        MOCK_STABLE_APP_CATALOG_NAMESPACE,
-        MOCK_APP_DEPLOY_NS,
-        MOCK_APP_DEPLOY_NS,
-        config_values=stable_config,
+    chart_file, chart_ver = runner._resolve_stable_chart(
+        _remote_upgrade_config(mocker), {}, MOCK_APP_NAME, "/tmp/ats-dl"
     )
-    mocker.patch.object(configured_app.app, "reload")
-    mocker.patch.object(configured_app.app, "update")
-    if configured_app.app_cm:
-        mocker.patch.object(configured_app.app_cm, "create")
-        mocker.patch.object(configured_app.app_cm, "reload")
-        mocker.patch.object(configured_app.app_cm, "update")
-        mocker.patch.object(configured_app.app_cm, "delete")
 
-    runner = UpgradeTestScenario(mocker.MagicMock(), PytestExecutor())
-    new_configured_app = runner._upgrade_app_cr(
-        configured_app,
+    assert chart_ver == MOCK_UPGRADE_APP_VERSION
+    assert chart_file == f"/tmp/ats-dl/{MOCK_APP_NAME}-{MOCK_UPGRADE_APP_VERSION}.tgz"
+    run_and_log = cast(Mock, app_test_suite.steps.scenarios.upgrade.run_and_log)
+    run_and_log.assert_called_once()
+    assert run_and_log.call_args.args[0] == [
+        _HELM_BIN,
+        "pull",
+        MOCK_APP_NAME,
+        "--repo",
+        MOCK_UPGRADE_CATALOG_URL,
+        "--version",
         MOCK_UPGRADE_APP_VERSION,
-        app_config_file_path=under_test_config_file,
-    )
+        "--destination",
+        "/tmp/ats-dl",
+    ]
+    assert run_and_log.call_args.kwargs["timeout"] == _HELM_PULL_TIMEOUT_SEC
 
-    assert new_configured_app.app.obj["spec"]["version"] == MOCK_UPGRADE_APP_VERSION
-    assert new_configured_app.app.obj["spec"]["catalog"] == TEST_APP_CATALOG_NAME
-    assert new_configured_app.app.obj["spec"]["catalogNamespace"] == TEST_APP_CATALOG_NAMESPACE
-    if expected_action == ExpectedAction.NO_CHANGE:
-        assert new_configured_app == configured_app
-        if new_configured_app.app_cm:
-            cast(Mock, new_configured_app.app_cm.update).assert_not_called()
-    elif expected_action == ExpectedAction.CM_UPDATED:
-        cast(Mock, new_configured_app.app_cm.update).assert_called_once()
-    elif expected_action == ExpectedAction.CM_DELETED:
-        cast(Mock, configured_app.app_cm.delete).assert_called_once()
-        assert new_configured_app.app_cm is None
-        assert "config" not in new_configured_app.app.obj["spec"]
-    elif expected_action == ExpectedAction.CM_CREATED:
-        assert new_configured_app.app_cm is not None
-        cast(Mock, new_configured_app.app_cm.create).assert_called_once()
-        assert "config" in new_configured_app.app.obj["spec"]
-        assert (
-            new_configured_app.app.obj["spec"]["config"]["configMap"]["name"]
-            == new_configured_app.app_cm.obj["metadata"]["name"]
-        )
-        assert (
-            new_configured_app.app.obj["spec"]["config"]["configMap"]["namespace"]
-            == new_configured_app.app_cm.obj["metadata"]["namespace"]
-        )
+
+def test_resolve_stable_chart_remote_pull_timeout(mocker: MockerFixture) -> None:
+    mocker.patch(
+        "app_test_suite.steps.scenarios.upgrade.run_and_log",
+        side_effect=subprocess.TimeoutExpired(cmd="helm pull", timeout=_HELM_PULL_TIMEOUT_SEC),
+    )
+    mocker.patch("app_test_suite.steps.scenarios.upgrade.TestInfoProvider")
+    runner = _make_remote_upgrade_runner(mocker)
+
+    with pytest.raises(ATSTestError, match="timed out"):
+        runner._resolve_stable_chart(_remote_upgrade_config(mocker), {}, MOCK_APP_NAME, "/tmp/ats-dl")
+
+
+def test_resolve_stable_chart_remote_pull_fails(mocker: MockerFixture) -> None:
+    failed = mocker.Mock(name="FailedPull")
+    failed.returncode = 1
+    mocker.patch("app_test_suite.steps.scenarios.upgrade.run_and_log", return_value=failed)
+    mocker.patch("app_test_suite.steps.scenarios.upgrade.TestInfoProvider")
+    runner = _make_remote_upgrade_runner(mocker)
+
+    with pytest.raises(ATSTestError, match="failed"):
+        runner._resolve_stable_chart(_remote_upgrade_config(mocker), {}, MOCK_APP_NAME, "/tmp/ats-dl")


### PR DESCRIPTION
## What

Switch all test scenarios (smoke, functional, upgrade) to deploy the chart under test directly with Helm, replacing the App CR / chartmuseum path. This implements the deploy-path goal from #633 using raw `helm`.

- Smoke / functional: `helm upgrade --install <release> <chart> --namespace <ns> --create-namespace --reset-values --wait --timeout 30m`; teardown with `helm uninstall --wait`.
- Upgrade: install the stable chart with helm (local `--upgrade-tests-app-file` or `helm pull` from the catalog URL), run pre-upgrade tests and hook, `helm upgrade` to the version under test, run post-upgrade tests and hook, `helm uninstall`.
- `--reset-values` keeps each deploy deterministic (chart defaults plus the provided values file), matching the previous App-CR behaviour where the under-test config replaced the stable config rather than inheriting it.
- `helm uninstall --wait`, a `helm pull` timeout, and the `--app-tests-skip-app-delete` fix below preserve the synchronous teardown / fail-fast download the App-CR path had.
- Test suites receive `ATS_RELEASE_NAME` and `ATS_RELEASE_NAMESPACE` to locate the deployed release.
- `helm` (v4, renovate-pinned) is bundled in the Docker image.

The App CR machinery (app-operator / chart-operator path, chartmuseum upload, `repositories.py`) is left in place but unused. It is removed in a separate follow-up cleanup PR so this change stays a focused, single-concern diff.

## Breaking changes

- Charts are deployed via Helm, so there is no longer an `App` CR for test suites to query. Suites that read the App CR must assert against the deployed workloads via the kube client, using `ATS_RELEASE_NAME` / `ATS_RELEASE_NAMESPACE`. The bundled pytest and Go examples already work this way and are unchanged.
- During the pre-upgrade test phase, `ATS_CHART_PATH` is now the local path of the stable chart `.tgz` rather than a remote chartmuseum URL. A suite that parsed it as a URL must read it as a filesystem path.
- Values files continue to be passed through `--app-tests-app-config-file` (forwarded to `helm --values`).

## Behaviour change worth calling out

- `--app-tests-skip-app-delete` now actually prevents teardown. The old condition (`not skip-deploy or not skip-delete`) silently ignored it whenever the chart had been deployed. Logged under `### Fixed` in the CHANGELOG.

## Notes / limitations

- `helm pull --repo` resolves against HTTP(S) chart repositories (chartmuseum). OCI catalog URLs (`oci://...`) are not handled here; commented in `_resolve_stable_chart`.
- `_helm_deploy` ensures the `policy-exceptions` namespace exists for Giant Swarm charts that ship `PolicyException` resources there; commented at the call site.
