### PR TITLE
fix: correct scenario error attribution, stale help, and pytest minversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), following
 
 - `--app-tests-skip-app-delete` now prevents teardown of the deployed chart. It was previously ignored whenever the chart had been deployed (only honored when `--app-tests-skip-app-deploy` was also set).
 - The `versions` command no longer fails with `apptestctl: command not found` after the `apptestctl` binary was dropped from the image.
+- Errors raised while running a test scenario now preserve the original exception as the cause and no longer report every failure as an "Application deployment failed", so pre-hook, test, and post-hook failures are attributed correctly.
 
 ### Removed
 

--- a/app_test_suite/steps/base.py
+++ b/app_test_suite/steps/base.py
@@ -54,13 +54,13 @@ class BaseTestScenariosFilteringPipeline(BuildStepsFilteringPipeline):
             self.KEY_CONFIG_OPTION_SKIP_DEPLOY_APP,
             required=False,
             action="store_true",
-            help="Skip automated app deployment for the test run to the test cluster (using an App CR).",
+            help="Skip automated app deployment for the test run to the test cluster (via 'helm upgrade --install').",
         )
         self._config_parser_group.add_argument(
             self.KEY_CONFIG_OPTION_SKIP_DELETE_APP,
             required=False,
             action="store_true",
-            help="Skip automated App CR and ConfigMap deletion for the test run to the test cluster.",
+            help="Skip automated teardown of the deployed chart (via 'helm uninstall') after the test run.",
         )
         self._config_parser_group.add_argument(
             self.KEY_CONFIG_OPTION_DEPLOY_NAMESPACE,
@@ -106,7 +106,7 @@ class BaseTestScenariosFilteringPipeline(BuildStepsFilteringPipeline):
                     yaml.safe_load(file)
             except Exception:
                 raise ATSTestError(
-                    f"Application config file '{app_config_file}' found, but can't be loadedas a correct YAML document."
+                    f"Application config file '{app_config_file}' found, but can't be loaded as a correct YAML document."
                 )
 
     def cleanup(

--- a/app_test_suite/steps/scenarios/simple.py
+++ b/app_test_suite/steps/scenarios/simple.py
@@ -229,7 +229,7 @@ class SimpleTestScenario(BuildStep, ABC):
             self._run_hook(config, context, "post")
         except Exception as e:
             self._collect_failure_diagnostics(config, context)
-            raise ATSTestError(f"Application deployment failed: {e}")
+            raise ATSTestError(f"Application test run failed: {e}") from e
         finally:
             # honor --app-tests-skip-app-delete; both delete helpers no-op when nothing was deployed
             if not get_config_value_by_cmd_line_option(

--- a/app_test_suite/steps/scenarios/upgrade.py
+++ b/app_test_suite/steps/scenarios/upgrade.py
@@ -121,7 +121,6 @@ class UpgradeTestScenario(SimpleTestScenario):
                     KEY_CFG_UPGRADE_HOOK,
                     f"Upgrade hook was configured, but '{cmd}' was not found to be a valid executable.",
                 )
-        self._test_executor.validate(config, self.name)
 
     def _resolve_stable_chart(
         self,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ name = "pypi"
 url = "https://pypi.org/simple"
 
 [tool.pytest.ini_options]
-minversion = "v0.15.0"
+minversion = "6.2.4"
 testpaths = ["tests"]
 
 [tool.ruff]


### PR DESCRIPTION
Follow-ups from a code review of the Helm-based deploy path. Five small, independent cleanups; only the exception-attribution change is user-observable.

### What changed

- **Scenario error attribution** (`scenarios/simple.py`): `run()` wrapped deploy, pre-hook, tests, and post-hook in one `try`, then re-raised every failure as `ATSTestError("Application deployment failed: ...")` with no cause. It now raises `"Application test run failed: ..."` with `from e`, so a pre-hook/test/post-hook failure is reported accurately and the original traceback is preserved.
- **Stale CLI help** (`steps/base.py`): `--app-tests-skip-app-deploy` and `--app-tests-skip-app-delete` still referenced App CRs and ConfigMaps. The tool deploys via `helm upgrade --install` and tears down via `helm uninstall`; the help text now says so.
- **Typo** (`steps/base.py`): "can't be loadedas a correct YAML" → "can't be loaded as a correct YAML".
- **pytest `minversion`** (`pyproject.toml`): was set to the project version `v0.15.0`, but `minversion` is the minimum pytest version. Set to the dev-dependency floor `6.2.4`.
- **Double validation** (`scenarios/upgrade.py`): `UpgradeTestScenario.pre_run` called `self._test_executor.validate(...)` after `super().pre_run()` already ran it. Removed the redundant call.

`project.version = "v0.15.0"` was left as-is: `make release` (`Makefile.ats.mk`) rewrites it with the `v`-prefixed tag, uv normalizes the prefix away (`uv version` → `0.15.0`), and PEP 440 tolerates a leading `v`. Dropping it would be reverted on the next release.

Does not touch #646.