### PR TITLE
fix: follow OCI tags/list pagination when discovering the stable version

### DIFF
--- a/app_test_suite/steps/scenarios/upgrade.py
+++ b/app_test_suite/steps/scenarios/upgrade.py
@@ -6,7 +6,8 @@ import re
 import shutil
 import subprocess
 from tempfile import TemporaryDirectory
-from typing import Tuple, cast, List, Match, Optional, Dict
+from typing import Tuple, cast, List, Match, Optional, Dict, Set
+from urllib.parse import urljoin
 
 import requests
 import yaml
@@ -319,23 +320,32 @@ class UpgradeTestScenario(SimpleTestScenario):
 
     @staticmethod
     def _list_oci_tags(registry_host: str, repository: str) -> List[str]:
-        tags_url = f"https://{registry_host}/v2/{repository}/tags/list"
+        next_url: Optional[str] = f"https://{registry_host}/v2/{repository}/tags/list"
+        request_headers: Dict[str, str] = {}
+        seen_urls: Set[str] = set()
+        tags: List[str] = []
         try:
-            response = requests.get(tags_url, timeout=_HTTP_TIMEOUT_SEC)
-            if response.status_code == 401:
-                token = UpgradeTestScenario._get_oci_pull_token(response, repository)
-                response = requests.get(
-                    tags_url, headers={"Authorization": f"Bearer {token}"}, timeout=_HTTP_TIMEOUT_SEC
-                )
-            if not response.ok:
-                raise ATSTestError(
-                    f"Couldn't list tags for '{repository}' from '{tags_url}'. "
-                    f"Reason: [{response.status_code}] {response.reason}."
-                )
-            tags = response.json().get("tags") or []
-            response.close()
+            while next_url and next_url not in seen_urls:
+                seen_urls.add(next_url)
+                response = requests.get(next_url, headers=request_headers, timeout=_HTTP_TIMEOUT_SEC)
+                if response.status_code == 401 and "Authorization" not in request_headers:
+                    token = UpgradeTestScenario._get_oci_pull_token(response, repository)
+                    request_headers["Authorization"] = f"Bearer {token}"
+                    response = requests.get(next_url, headers=request_headers, timeout=_HTTP_TIMEOUT_SEC)
+                if not response.ok:
+                    raise ATSTestError(
+                        f"Couldn't list tags for '{repository}' from '{next_url}'. "
+                        f"Reason: [{response.status_code}] {response.reason}."
+                    )
+                tags.extend(response.json().get("tags") or [])
+                next_link = response.links.get("next", {}).get("url")
+                next_url = urljoin(next_url, next_link) if next_link else None
+                response.close()
         except RequestException as e:
-            logger.error(f"Error when trying to list tags for '{repository}' from '{tags_url}': '{e}'.")
+            logger.error(
+                f"Error when trying to list tags for '{repository}' from"
+                f" 'https://{registry_host}/v2/{repository}/tags/list': '{e}'."
+            )
             raise
         return tags
 

--- a/tests/scenarios/test_upgrade_scenario.py
+++ b/tests/scenarios/test_upgrade_scenario.py
@@ -365,6 +365,7 @@ def _mock_tags_response(mocker: MockerFixture, status_code: int, tags: list) -> 
     response.ok = 300 > status_code >= 200
     response.reason = "OK" if response.ok else "Unauthorized"
     response.headers = {}
+    response.links = {}
     response.json.return_value = {"name": "repo", "tags": tags}
     return response
 
@@ -428,7 +429,9 @@ def test_get_latest_stable_oci_version_skips_prereleases_and_unparseable(mocker:
 
     assert runner._get_latest_stable_oci_version(MOCK_OCI_CATALOG_URL, MOCK_APP_NAME) == "1.1.0"
     cast(Mock, app_test_suite.steps.scenarios.upgrade.requests.get).assert_called_once_with(
-        f"https://giantswarmpublic.azurecr.io/v2/giantswarm-catalog/{MOCK_APP_NAME}/tags/list", timeout=10
+        f"https://giantswarmpublic.azurecr.io/v2/giantswarm-catalog/{MOCK_APP_NAME}/tags/list",
+        headers={},
+        timeout=10,
     )
 
 
@@ -466,3 +469,23 @@ def test_get_latest_stable_oci_version_handles_token_auth(mocker: MockerFixture)
     assert get_mock.call_args_list[1].args[0] == "https://auth.example.com/token"
     # authenticated retry carries the bearer token
     assert get_mock.call_args_list[2].kwargs["headers"] == {"Authorization": "Bearer secret-token"}
+
+
+def test_get_latest_stable_oci_version_follows_link_pagination(mocker: MockerFixture) -> None:
+    base = f"https://giantswarmpublic.azurecr.io/v2/giantswarm-catalog/{MOCK_APP_NAME}/tags/list"
+    page1 = _mock_tags_response(mocker, 200, ["1.0.0", "1.1.0"])
+    page1.links = {"next": {"url": f"/v2/giantswarm-catalog/{MOCK_APP_NAME}/tags/list?last=1.1.0&n=2"}}
+    # the newest stable tag lives only on the second page
+    page2 = _mock_tags_response(mocker, 200, ["1.2.0", "2.0.0-rc.1"])
+
+    get_mock = mocker.patch(
+        "app_test_suite.steps.scenarios.upgrade.requests.get",
+        side_effect=[page1, page2],
+    )
+    runner = _make_remote_upgrade_runner(mocker)
+
+    assert runner._get_latest_stable_oci_version(MOCK_OCI_CATALOG_URL, MOCK_APP_NAME) == "1.2.0"
+    assert get_mock.call_count == 2
+    assert get_mock.call_args_list[0].args[0] == base
+    # the relative rel="next" link is resolved against the current page URL
+    assert get_mock.call_args_list[1].args[0] == f"{base}?last=1.1.0&n=2"


### PR DESCRIPTION
Follow-up from review of #646. Targets `feat/oci-stable-chart-pull` (the #646 branch) since the OCI code isn't on `main` yet; retarget to `main` if #646 merges first.

### Problem

`_list_oci_tags` read a single `GET /v2/<repo>/tags/list` response. The OCI Distribution spec paginates large tag lists via the RFC 5988 `Link` header (`rel="next"`). In a catalog large enough to paginate, the newest tag can land on a later page, so `stable` discovery could resolve to an older version or miss the tag entirely.

### Change

Follow the `Link: rel="next"` chain, accumulating tags across all pages before picking the latest stable version. Details:

- Bearer token obtained from the initial `401` challenge is reused across pages.
- Relative `next` URLs are resolved against the current page URL (`urljoin`).
- A visited-URL guard stops a registry that returns a cyclic `Link` from looping forever.

`requests.Response.links` is used to parse the header, so there's no hand-rolled RFC 5988 parsing.

### Tests

Added `test_get_latest_stable_oci_version_follows_link_pagination`: two-page mock where the newest stable tag exists only on the second page; asserts both pages are fetched and the relative `next` link is resolved correctly. Existing OCI tests updated for the new call shape (`headers` now always passed).

### Live validation

Not possible from this network: `oci://giantswarmpublic.azurecr.io/giantswarm-catalog` is behind an ACR IP firewall (token endpoint returns `403 DENIED, client with IP ... is not allowed access`). The `WWW-Authenticate` challenge parses correctly (realm/service/scope extracted); pagination is covered by unit tests. Worth a one-time check from an allowlisted network before relying on it against very large catalogs.