### PR TITLE
feat: support installation as a uv tool published to PyPI

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,0 +1,24 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write  # required for OIDC trusted publishing
+
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+
+      - name: Build
+        run: uv build
+
+      - name: Publish
+        run: uv publish

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), following
 
 ### Added
 
+- `ats` can now be installed directly as a Python CLI tool with `uv tool install app-test-suite` (published to PyPI on every `v*` tag via OIDC trusted publishing). In this mode you provide the required binaries (`helm`, `kubectl`, and `kind`/`docker` or `go` as needed) yourself, without pulling the Docker image. See the README "With uv" section.
 - OCI catalog URLs (`oci://...`) are now supported for `--upgrade-tests-app-catalog-url`; `helm pull oci://<url>/<chart>` is used automatically.
 - `--upgrade-tests-app-version stable` (the new default) discovers the latest stable (non-prerelease) version to upgrade from, for both HTTP(S) chart repositories (via `index.yaml`) and OCI registries (via the registry tags API).
 - Test suites receive `ATS_RELEASE_NAME` and `ATS_RELEASE_NAMESPACE` environment variables identifying the deployed Helm release and the namespace it was installed into.

--- a/Makefile.ats.mk
+++ b/Makefile.ats.mk
@@ -31,7 +31,7 @@ release: release_ver_to_code docker-test docker-build-image
 
 release_ver_to_code:
 	$(call check_defined, TAG)
-	sed -i 's/version = ".*"/version = "'${TAG}'"/' pyproject.toml
+	sed -i "s/version = \".*\"/version = \"$${TAG#v}\"/" pyproject.toml
 	uv lock
 	echo "build_ver = \"${TAG}\"" > app_test_suite/version.py
 	$(eval IMG_VER := ${TAG})

--- a/README.md
+++ b/README.md
@@ -37,7 +37,49 @@ To build the Chart, please consider the companion [app-build-suite](https://gith
 
 ### Installation
 
-`ats` is distributed as a docker image, so you run it directly with `docker run`. The interactive run command is:
+#### With uv
+
+You can install `app-test-suite` as a command line tool invoked with the `ats` command. In this mode you're
+responsible for installing all the binary dependencies that `ats` needs to work.
+
+This mode doesn't need docker to run `ats` itself, so it's a good match for all the systems built with isolation
+and sandboxing in mind, like CI/CD or AI agents running in isolated jails/sandboxes.
+
+The main tool you need is [uv](https://github.com/astral-sh/uv). Please refer to the
+[uv installation documentation](https://docs.astral.sh/uv/getting-started/installation/) for instructions on how
+to install it.
+
+Depending on the test scenarios and cluster provider you use, you also need some of the following binaries
+installed and available on your `PATH`:
+
+- [helm](https://helm.sh/docs/intro/install/) (always required)
+- [kubectl](https://kubernetes.io/docs/tasks/tools/) (always required)
+- [kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) and a working
+  [docker](https://docs.docker.com/get-docker/) daemon (only when using the built-in `kind` cluster provider)
+- [go](https://go.dev/doc/install) (only when using the `gotest` test executor)
+
+Then, to install `ats`, just run:
+
+```bash
+uv tool install app-test-suite
+```
+
+Check the installation:
+
+```bash
+ats --version
+```
+
+To upgrade:
+
+```bash
+uv tool upgrade app-test-suite
+```
+
+#### With docker
+
+`ats` is also distributed as a docker image, so you can run it directly with `docker run`. This bundles all the
+binary dependencies for you, but requires access to the docker socket. The interactive run command is:
 
 ```bash
 docker run --rm -it \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "app_test_suite"
-version = "v0.15.0"
+version = "0.15.0"
 requires-python = ">=3.12"
 description = "An app testing suite for GiantSwarm app platform"
 readme = "README.md"


### PR DESCRIPTION
Closes #656

Makes `app-test-suite` installable directly as a Python CLI with `uv tool install app-test-suite`, the same way [app-build-suite](https://github.com/giantswarm/app-build-suite) is (mirrors ABS commit `0b26061`). No Docker image needed for this path.

## Changes

- **`.github/workflows/publish-to-pypi.yml`** (new) — on every `v*` tag, `uv build` → `uv publish` to PyPI via OIDC trusted publishing (`environment: pypi`). Identical to the ABS workflow.
- **`pyproject.toml`** — normalize the packaged version to PEP 440 (`v0.15.0` → `0.15.0`). The `ats` console-script entry point and the `uv_build` backend were already in place.
- **`Makefile.ats.mk`** — `release_ver_to_code` now writes `${TAG#v}` into `pyproject.toml` so future releases stay prefix-free.
- **`README.md`** — Installation split into **With uv** (`uv tool install app-test-suite` + the binary deps you provide yourself: `helm`, `kubectl`, and `kind`/`docker` or `go` as needed) and **With docker** (existing flow).
- **`CHANGELOG.md`** — note the new install method.

## ⚠️ Required one-time external setup

`app-test-suite` is not yet on PyPI, and the workflow uses OIDC trusted publishing (no API token). Before the first tagged release can publish, someone with the right access must:

1. On PyPI, add a **pending trusted publisher** for a new project `app-test-suite` → repo `giantswarm/app-test-suite`, workflow `publish-to-pypi.yml`, environment `pypi`.
2. In the GitHub repo settings, create an **environment named `pypi`**.

This is the same setup done for ABS; it can't be committed to the repo.

## Verification

- `uv build` produces `app_test_suite-0.15.0-*` artifacts (PEP 440-clean).
- `uv run ats --version` resolves the entry point.
- All pre-commit hooks pass (markdownlint included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)