### PR TITLE
fix: discover tests relative to the working directory, not the chart file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), following
 
 ### Fixed
 
+- Tests are now discovered relative to the executing directory (the current working directory) instead of relative to the location of the `--chart-file` archive, so the chart `.tgz` can live anywhere (e.g. a build output directory) without having to be moved next to your `tests/ats` directory ([#196](https://github.com/giantswarm/app-test-suite/issues/196)). The `.ats/main.yaml` config file is likewise now discovered relative to the working directory. For backward compatibility, if the test directory isn't found relative to the working directory but exists next to the chart file, the old location is used with a deprecation warning; when both a working-directory and a chart-file config exist, the chart-file one still takes precedence.
 - `--app-tests-skip-app-delete` now prevents teardown of the deployed chart. It was previously ignored whenever the chart had been deployed (only honored when `--app-tests-skip-app-deploy` was also set).
 - The `versions` command no longer fails with `apptestctl: command not found` after the `apptestctl` binary was dropped from the image.
 - Errors raised while running a test scenario now preserve the original exception as the cause and no longer report every failure as an "Application deployment failed", so pre-hook, test, and post-hook failures are attributed correctly.

--- a/README.md
+++ b/README.md
@@ -138,15 +138,17 @@ As an example, we have included a chart
 in this repository in
 [`examples/apps/hello-world-app`](examples/apps/hello-world-app). Its configuration file for
 `ats` is in the [.ats/main.yaml](examples/apps/hello-world-app/.ats/main.yaml) file.
-To test the chart using `ats`
-and the provided config file, run:
+`ats` discovers tests and its `.ats/main.yaml` config relative to the directory you run it from (the working
+directory), independently of where the `-c` chart archive lives. To test the chart using `ats` and the
+provided config file, run it from the chart's directory:
 
 ```bash
-ats -c examples/apps/hello-world-app/hello-world-app-0.2.3-90e2f60e6810ddf35968221c193340984236fe2a.tgz
+cd examples/apps/hello-world-app
+ats -c hello-world-app-0.2.3-90e2f60e6810ddf35968221c193340984236fe2a.tgz
 ```
 
-To run it, you need to have an existing Kubernetes cluster. `kube.config` file needed to authorize with it
-needs to be saved in the root directory of this repository. If you have `kind`, you can create the cluster
+To run it, you need to have an existing Kubernetes cluster. The bundled `.ats/main.yaml` points `ats` at a
+`kube.config` file in the working directory. If you have `kind`, you can create the cluster
 and its config file like this:
 
 ```bash
@@ -180,7 +182,8 @@ After bootstrapping, `ats` starts executing test scenarios. Currently, we have 3
 look at what happens when you execute:
 
 ```bash
-ats -c examples/apps/hello-world-app/hello-world-app-0.2.3-90e2f60e6810ddf35968221c193340984236fe2a.tgz \
+# run from the chart's directory (examples/apps/hello-world-app), where tests/ats lives
+ats -c hello-world-app-0.2.3-90e2f60e6810ddf35968221c193340984236fe2a.tgz \
   --functional-tests-cluster-type external \
   --smoke-tests-cluster-type external \
   --skip-steps upgrade \

--- a/app_test_suite/__main__.py
+++ b/app_test_suite/__main__.py
@@ -141,27 +141,33 @@ def configure_test_specific_options(config_parser: configargparse.ArgParser) -> 
     )
 
 
-def get_default_config_file_path() -> str:
+def get_default_config_file_paths() -> List[str]:
     base_dir = os.getcwd()
+    # The config file is looked up relative to the executing directory (the current working directory),
+    # so it can be provided independently of where the chart archive lives (see issue #196).
+    cwd_config_path = os.path.join(base_dir, ".ats", "main.yaml")
+    config_paths = [cwd_config_path]
+    # Backward compatibility: also look for the config next to the chart file. When both files exist,
+    # the chart-file-relative one is parsed last and thus takes precedence, preserving legacy behaviour.
     short_opt = "-c"
     long_opt = "--chart-file"
     if short_opt in sys.argv or long_opt in sys.argv:
         opt = short_opt if short_opt in sys.argv else long_opt
         c_ind = sys.argv.index(opt)
         chart_dir = os.path.dirname(sys.argv[c_ind + 1])
-        config_path = os.path.join(base_dir, chart_dir, ".ats", "main.yaml")
-    else:
-        config_path = os.path.join(base_dir, ".ats", "main.yaml")
-    logger.debug(f"Using {config_path} as configuration file path.")
-    return config_path
+        chart_config_path = os.path.join(base_dir, chart_dir, ".ats", "main.yaml")
+        if os.path.normpath(chart_config_path) != os.path.normpath(cwd_config_path):
+            config_paths.append(chart_config_path)
+    logger.debug(f"Using {config_paths} as configuration file path candidates.")
+    return config_paths
 
 
 def get_global_config_parser(add_help: bool = True) -> configargparse.ArgParser:
-    config_file_path = get_default_config_file_path()
+    config_file_paths = get_default_config_file_paths()
     config_parser = configargparse.ArgParser(
         prog=app_name,
         add_config_file_help=True,
-        default_config_files=[config_file_path],
+        default_config_files=config_file_paths,
         description="Test Giant Swarm App Platform app.",
         add_env_var_help=True,
         auto_env_var_prefix="ATS_",

--- a/app_test_suite/steps/base.py
+++ b/app_test_suite/steps/base.py
@@ -165,6 +165,33 @@ class TestExecutor(ABC):
         """Validate any configuration related to the test executor."""
         raise NotImplementedError()
 
+    @staticmethod
+    def _resolve_test_dir(config: argparse.Namespace, configured_dir: str) -> str:
+        """Resolve the directory that holds the test source code.
+
+        Tests are discovered relative to the executing directory (the current working directory),
+        which decouples test discovery from the location of the chart archive under test, so the
+        chart file can live anywhere (see issue #196). An absolute ``configured_dir`` is honored
+        verbatim.
+
+        For backward compatibility, if the directory isn't found relative to the working directory
+        but does exist relative to the chart file's directory (the legacy behaviour), that location
+        is used and a deprecation warning is logged.
+        """
+        cwd_dir = os.path.join(os.getcwd(), configured_dir)
+        if os.path.isdir(cwd_dir):
+            return cwd_dir
+        legacy_dir = os.path.join(os.path.dirname(os.path.abspath(config.chart_file)), configured_dir)
+        if os.path.isdir(legacy_dir):
+            logger.warning(
+                f"Test source directory '{cwd_dir}' was not found relative to the working directory, but "
+                f"'{legacy_dir}' relative to the chart file was; using the latter for backward compatibility. "
+                f"This fallback is deprecated: place your tests relative to the working directory (or pass an "
+                f"absolute test directory) instead."
+            )
+            return legacy_dir
+        return cwd_dir
+
     def prepare_test_environment(self, exec_info: TestExecInfo) -> None:
         """Optional step to prepare environment where your tests are executed (ie. installing dependencies)."""
         raise NotImplementedError()

--- a/app_test_suite/steps/executors/gotest.py
+++ b/app_test_suite/steps/executors/gotest.py
@@ -108,7 +108,7 @@ class GotestExecutor(TestExecutor):
         gotest_dir = get_config_value_by_cmd_line_option(
             config, GotestTestFilteringPipeline.KEY_CONFIG_OPTION_GOTEST_DIR
         )
-        gotest_dir = os.path.join(os.path.dirname(config.chart_file), gotest_dir)
+        gotest_dir = self._resolve_test_dir(config, gotest_dir)
         if not os.path.isdir(gotest_dir):
             raise ValidationError(
                 module_name,

--- a/app_test_suite/steps/executors/pytest.py
+++ b/app_test_suite/steps/executors/pytest.py
@@ -91,7 +91,7 @@ class PytestExecutor(TestExecutor):
         pytest_dir = get_config_value_by_cmd_line_option(
             config, PytestScenariosFilteringPipeline.KEY_CONFIG_OPTION_PYTEST_DIR
         )
-        pytest_dir = os.path.join(os.path.dirname(config.chart_file), pytest_dir)
+        pytest_dir = self._resolve_test_dir(config, pytest_dir)
         if not os.path.isdir(pytest_dir):
             raise ValidationError(
                 module_name,

--- a/docs/gotest-test-pipeline.md
+++ b/docs/gotest-test-pipeline.md
@@ -6,7 +6,10 @@ as similar as possible so we can reuse functionality.
 
 To make your tests automatically invocable from `ats`, you must adhere to the following rules:
 
-- you must put all the test code in `[CHART_TOP_DIR]/tests/ats/` directory,
+- you must put all the test code in the `tests/ats/` directory relative to where you run `ats` from (the
+  working directory); this is decoupled from the `--chart-file` archive location, so the chart `.tgz` can
+  live anywhere. Override the location with `--app-tests-gotest-tests-dir` (relative to the working
+  directory, or an absolute path),
 - you must set `--test-executor` to `gotest`,
 - in your test the kubeconfig path can be retrieved from the env var `KUBECONFIG`
 - tests must be tagged using Go build tags with one of the supported test types

--- a/docs/pytest-test-pipeline.md
+++ b/docs/pytest-test-pipeline.md
@@ -9,7 +9,10 @@ for a complete usage example.
 
 To make your tests automatically invocable from `ats`, you must adhere to the following rules:
 
-- put all test code in `[CHART_TOP_DIR]/tests/ats/`
+- put all test code in the `tests/ats/` directory relative to where you run `ats` from (the working
+  directory). This is decoupled from the `--chart-file` archive location, so the chart `.tgz` can live
+  anywhere. Override the location with `--app-tests-pytest-tests-dir` (relative to the working directory,
+  or an absolute path).
 - manage dependencies with [`uv`](https://docs.astral.sh/uv/): the directory must contain a `pyproject.toml`
   and a committed `uv.lock`. `ats` runs `uv sync` before each test run and invokes tests with `uv run pytest`.
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -59,14 +59,14 @@ mkdir examples/tutorial
 cp -a examples/apps/hello-world-app/hello-world-app-0.2.3-90e2f60e6810ddf35968221c193340984236fe2a.tgz examples/tutorial
 ```
 
-Let's create a directory for storing tests. `ats` looks for them in the `tests/ats` subdirectory of the helm
-chart, so let's initialise a uv project there:
+Let's create a directory for storing tests. `ats` looks for them in the `tests/ats` subdirectory relative to
+the directory you run `ats` from (the working directory), so let's initialise a uv project there:
 
 ```bash
-$ mkdir -p examples/tutorial/tests/ats
-$ cd examples/tutorial/tests/ats
-$ uv init --no-workspace --no-readme
-$ uv add "pytest-helm-charts>=0.5"
+mkdir -p examples/tutorial/tests/ats
+cd examples/tutorial/tests/ats
+uv init --no-workspace --no-readme
+uv add "pytest-helm-charts>=0.5"
 ```
 
 As a result, the `pyproject.toml` should look like this:
@@ -127,13 +127,15 @@ We are now ready to build our test chart again, but this time running tests we'v
 need to have a cluster where we can deploy our chart and then execute our tests against a running application.
 Do make this time efficient, we'll use [kind](https://kind.sigs.k8s.io/docs/user/quick-start/). We're going to
 use embedded `ats` ability to create `kind` clusters, but remember that you can use any existing cluster you
-like - you just need to pass a `kube.config` file to `ats`. Switch back to the root directory of this
-repository. `ats` can run different types of tests on different clusters, so we have to pass cluster type
+like - you just need to pass a `kube.config` file to `ats`. Run `ats` from the `examples/tutorial` directory,
+so it discovers the tests in `tests/ats` relative to it (the chart archive passed with `-c` can live
+anywhere). `ats` can run different types of tests on different clusters, so we have to pass cluster type
 option twice, but our cluster will be reused for both kinds of tests:
 
 ```bash
 # log truncated to key steps
-ats -c examples/tutorial/hello-world-app-0.2.3-90e2f60e6810ddf35968221c193340984236fe2a.tgz \
+cd examples/tutorial
+ats -c hello-world-app-0.2.3-90e2f60e6810ddf35968221c193340984236fe2a.tgz \
     --smoke-tests-cluster-type kind --functional-tests-cluster-type kind
 ...
 INFO: Running pre-run step for TestInfoProvider
@@ -145,11 +147,11 @@ INFO: Cluster CRDs bootstrapped and ready.
 INFO: Ensuring namespace 'policy-exceptions'.
 INFO: Installing chart as Helm release 'hello-world-app' into namespace 'default'.
 INFO: Running command: helm upgrade --install hello-world-app \
-    examples/tutorial/hello-world-app-0.2.3-....tgz \
+    hello-world-app-0.2.3-....tgz \
     --namespace default --create-namespace --reset-values --wait --timeout 30m
 ...
-INFO: Running 'uv sync' in 'examples/tutorial/tests/ats' to install test virtual env.
-INFO: Running pytest tool in 'examples/tutorial/tests/ats' directory.
+INFO: Running 'uv sync' in 'tests/ats' to install test virtual env.
+INFO: Running pytest tool in 'tests/ats' directory.
 INFO: Running command: uv run pytest -m smoke --log-cli-level info --junitxml=test_results_smoke.xml
 
 test_example.py::test_we_have_environment PASSED                                [100%]

--- a/tests/scenarios/executors/test_test_dir_resolution.py
+++ b/tests/scenarios/executors/test_test_dir_resolution.py
@@ -1,0 +1,141 @@
+"""Tests for test source directory discovery (issue #196).
+
+Tests must be discovered relative to the executing directory (the current working directory), so the
+chart archive under test can live anywhere. A legacy fallback to the chart-file-relative location is
+kept for backward compatibility.
+"""
+
+import argparse
+import os
+from pathlib import Path
+
+import pytest
+from _pytest.logging import LogCaptureFixture
+from pytest_mock import MockerFixture
+from step_exec_lib.errors import ValidationError
+
+from app_test_suite.steps.base import TestExecutor
+from app_test_suite.steps.executors.gotest import GotestExecutor
+from app_test_suite.steps.executors.pytest import PytestExecutor
+
+PYTEST_TESTS_DIR_ATTR = "app_tests_pytest_tests_dir"
+GOTEST_TESTS_DIR_ATTR = "app_tests_gotest_tests_dir"
+DEFAULT_TESTS_DIR = os.path.join("tests", "ats")
+
+
+def _make_config(chart_file: str, tests_dir: str = DEFAULT_TESTS_DIR) -> argparse.Namespace:
+    config = argparse.Namespace()
+    config.chart_file = chart_file
+    setattr(config, PYTEST_TESTS_DIR_ATTR, tests_dir)
+    setattr(config, GOTEST_TESTS_DIR_ATTR, tests_dir)
+    return config
+
+
+def _touch(dir_path: Path, file_name: str) -> None:
+    dir_path.mkdir(parents=True, exist_ok=True)
+    (dir_path / file_name).write_text("x")
+
+
+def test_resolve_test_dir_prefers_working_directory(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # tests live relative to the working directory; the chart archive lives somewhere else entirely
+    project = tmp_path / "project"
+    (project / "tests" / "ats").mkdir(parents=True)
+    chart_file = tmp_path / "charts" / "mychart.tgz"
+    chart_file.parent.mkdir(parents=True)
+    chart_file.write_text("x")
+    monkeypatch.chdir(project)
+
+    resolved = TestExecutor._resolve_test_dir(_make_config(str(chart_file)), DEFAULT_TESTS_DIR)
+
+    assert resolved == str(project / "tests" / "ats")
+
+
+def test_resolve_test_dir_falls_back_to_chart_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: LogCaptureFixture
+) -> None:
+    # legacy layout: no tests relative to CWD, but they exist next to the chart file
+    root = tmp_path / "root"
+    (root / "sub" / "tests" / "ats").mkdir(parents=True)
+    chart_file = root / "sub" / "mychart.tgz"
+    chart_file.write_text("x")
+    monkeypatch.chdir(root)
+
+    import logging
+
+    with caplog.at_level(logging.WARNING):
+        resolved = TestExecutor._resolve_test_dir(_make_config(str(chart_file)), DEFAULT_TESTS_DIR)
+
+    assert resolved == str(root / "sub" / "tests" / "ats")
+    assert any("deprecated" in rec.message for rec in caplog.records)
+
+
+def test_resolve_test_dir_points_at_cwd_when_nothing_found(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    chart_file = tmp_path / "mychart.tgz"
+    chart_file.write_text("x")
+    monkeypatch.chdir(tmp_path)
+
+    resolved = TestExecutor._resolve_test_dir(_make_config(str(chart_file)), DEFAULT_TESTS_DIR)
+
+    # points at the recommended working-directory-relative location so the error message guides the user there
+    assert resolved == str(tmp_path / "tests" / "ats")
+
+
+def test_resolve_test_dir_honors_absolute_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    abs_tests = tmp_path / "elsewhere" / "mytests"
+    abs_tests.mkdir(parents=True)
+    chart_file = tmp_path / "charts" / "mychart.tgz"
+    chart_file.parent.mkdir(parents=True)
+    chart_file.write_text("x")
+    monkeypatch.chdir(tmp_path)
+
+    resolved = TestExecutor._resolve_test_dir(_make_config(str(chart_file), str(abs_tests)), str(abs_tests))
+
+    assert resolved == str(abs_tests)
+
+
+def test_pytest_validate_discovers_tests_in_cwd_with_chart_elsewhere(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture
+) -> None:
+    project = tmp_path / "project"
+    _touch(project / "tests" / "ats", "test_example.py")
+    chart_file = tmp_path / "charts" / "mychart.tgz"
+    chart_file.parent.mkdir(parents=True)
+    chart_file.write_text("x")
+    monkeypatch.chdir(project)
+    mocker.patch("app_test_suite.steps.executors.pytest.shutil.which", return_value="/usr/bin/uv")
+
+    executor = PytestExecutor()
+    executor.validate(_make_config(str(chart_file)), "SmokeTestScenario")
+
+    assert executor._test_dir == str(project / "tests" / "ats")
+
+
+def test_gotest_validate_discovers_tests_in_cwd_with_chart_elsewhere(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    project = tmp_path / "project"
+    _touch(project / "tests" / "ats", "main_test.go")
+    chart_file = tmp_path / "charts" / "mychart.tgz"
+    chart_file.parent.mkdir(parents=True)
+    chart_file.write_text("x")
+    monkeypatch.chdir(project)
+
+    executor = GotestExecutor()
+    executor.validate(_make_config(str(chart_file)), "SmokeTestScenario")
+
+    assert executor._test_dir == str(project / "tests" / "ats")
+
+
+def test_pytest_validate_errors_point_at_working_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture
+) -> None:
+    chart_file = tmp_path / "charts" / "mychart.tgz"
+    chart_file.parent.mkdir(parents=True)
+    chart_file.write_text("x")
+    monkeypatch.chdir(tmp_path)
+    mocker.patch("app_test_suite.steps.executors.pytest.shutil.which", return_value="/usr/bin/uv")
+
+    with pytest.raises(ValidationError) as exc_info:
+        PytestExecutor().validate(_make_config(str(chart_file)), "SmokeTestScenario")
+
+    assert str(tmp_path / "tests" / "ats") in exc_info.value.msg


### PR DESCRIPTION
## What

Fixes #196.

Test discovery was anchored to the directory of the `--chart-file` archive — `os.path.dirname(config.chart_file)/tests/ats` — so the chart `.tgz` had to sit next to your `tests/ats` directory for tests to be found. If the chart lived anywhere else (e.g. a build output directory), discovery failed with *"the configured test source code directory '…/tests/ats' doesn't exist"*.

This decouples the two, as requested in the issue:

- **Tests are discovered relative to the executing directory** (the current working directory), independently of where the chart archive lives.
- A shared `TestExecutor._resolve_test_dir` helper implements the resolution for both the `pytest` and `gotest` executors; **absolute** test directories are honored verbatim.
- **`.ats/main.yaml` config discovery** is likewise now working-directory-relative, so a config in your project is picked up when the chart lives elsewhere.

## Backward compatibility

- If the test directory isn't found relative to the working directory **but exists next to the chart file**, the old location is used and a **deprecation warning** is logged. Existing chart-adjacent layouts keep working.
- Config-file discovery keeps the chart-file-relative `.ats/main.yaml` as a candidate; when both a working-directory and a chart-file config exist, the **chart-file one still takes precedence** (preserving prior behaviour).

## Changes

- `app_test_suite/steps/base.py` — new `TestExecutor._resolve_test_dir` helper (CWD-first, chart-dir fallback with deprecation warning).
- `app_test_suite/steps/executors/{pytest,gotest}.py` — `validate()` uses the helper instead of anchoring to the chart directory.
- `app_test_suite/__main__.py` — `.ats/main.yaml` discovered relative to the working directory (chart-dir kept as lower-precedence candidate).
- Docs (README, tutorial, pytest/gotest pipeline docs) — run `ats` from the chart's directory.
- `tests/scenarios/executors/test_test_dir_resolution.py` — new regression tests.

## Testing

- New regression tests cover: CWD discovery with the chart elsewhere, the legacy chart-dir fallback + warning, the "nothing found" error pointing at the CWD location, absolute dirs, and end-to-end `validate()` for both executors.
- Full suite: **48 passed, 1 skipped**; `ruff check` / `ruff format --check` clean; `mypy` clean; all pre-commit hooks pass.
- Verified the documented "run from the chart's directory" flow resolves with **no** deprecation warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)