### PR TITLE
feat: add option to deploy Flux to the test cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), following
 
 ### Added
 
+- `--app-tests-deploy-flux`: deploy Flux (CRDs and controllers) to the test cluster before the chart under test is
+  deployed, and wait until the controllers are available. Enables testing app bundles that include Flux resources
+  like `Kustomization` or `HelmRelease`. The Flux manifest (`install.yaml` from the pinned `fluxcd/flux2` release,
+  renovate-tracked) is bundled in the container image at `/etc/ats/flux/install.yaml`.
 - `ats` can now be installed directly as a Python CLI tool with `uv tool install app-test-suite` (published to PyPI on every `v*` tag via OIDC trusted publishing). In this mode you provide the required binaries (`helm`, `kubectl`, and `kind`/`docker` or `go` as needed) yourself, without pulling the Docker image. See the README "With uv" section.
 - OCI catalog URLs (`oci://...`) are now supported for `--upgrade-tests-app-catalog-url`; `helm pull oci://<url>/<chart>` is used automatically.
 - `--upgrade-tests-app-version stable` (the new default) discovers the latest stable (non-prerelease) version to upgrade from, for both HTTP(S) chart repositories (via `index.yaml`) and OCI registries (via the registry tags API).

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,12 @@ ARG DOCKER_VER=v28.5.2
 ARG KIND_VER=v0.32.0
 # renovate: datasource=github-releases depName=helm/helm
 ARG HELM_VER=v4.2.2
+# renovate: datasource=github-releases depName=fluxcd/flux2
+ARG FLUX_VER=v2.9.0
 
 RUN apk add --no-cache ca-certificates curl \
-    && mkdir -p /binaries \
+    && mkdir -p /binaries /manifests \
+    && curl --silent --show-error --fail --location https://github.com/fluxcd/flux2/releases/download/${FLUX_VER}/install.yaml --output /manifests/flux-install.yaml \
     && DOCKER_ARCH=$([ "${TARGETARCH}" = "arm64" ] && echo "aarch64" || echo "x86_64") \
     && curl --silent --show-error --fail --location https://dl.k8s.io/release/${KUBECTL_VER}/bin/linux/${TARGETARCH}/kubectl --output /binaries/kubectl \
     && curl --silent --show-error --fail --location https://download.docker.com/linux/static/stable/${DOCKER_ARCH}/docker-${DOCKER_VER##v}.tgz | \
@@ -89,6 +92,7 @@ COPY --from=builder ${ATS_DIR}/.venv ${ATS_DIR}/.venv
 
 COPY --from=binaries /binaries/* /usr/local/bin/
 COPY container-crds/*.yaml /etc/ats/crds/
+COPY --from=binaries /manifests/flux-install.yaml /etc/ats/flux/install.yaml
 
 # we assume the user will be using UID==1000 and GID=1000; if that's not true, we'll run `chown`
 # in the container's startup script

--- a/README.md
+++ b/README.md
@@ -167,6 +167,12 @@ Each run consist of two stages: bootstrapping and test execution.
 - if you configured your run with `*-tests-cluster-type kind`, a cluster is created with `kind` tool
 - `ats` connects to the target test cluster and applies the bundled CRDs with
   `kubectl apply --server-side -f /etc/ats/crds` (the CRDs vendored in `container-crds/`; no operators are installed)
+- if you pass the `--app-tests-deploy-flux` option, `ats` deploys [Flux](https://fluxcd.io) (CRDs and controllers)
+  to the test cluster and waits until the controllers are available. Enable this when your chart is a bundle that
+  includes Flux resources like `Kustomization` or `HelmRelease`, so the resources are actually reconciled during
+  the test. The Flux manifest (`install.yaml` from the pinned [fluxcd/flux2](https://github.com/fluxcd/flux2)
+  release) is bundled in the container image at `/etc/ats/flux/install.yaml`; when running `ats` outside the
+  container, download it from a flux2 release and place it at that path.
 - `ats` deploys your chart under test directly with Helm (`helm upgrade --install`); your application defined in the
   chart is deployed to the test cluster (you can disable this with the `app-tests-skip-app-deploy` option; this might
   be needed if you need more control over your test, like setting up additional CRDs or installing additional apps).

--- a/app_test_suite/cluster_providers/cluster_provider.py
+++ b/app_test_suite/cluster_providers/cluster_provider.py
@@ -28,8 +28,10 @@ class ClusterInfo:
     managing_provider: "ClusterProvider"
     # cluster might have an optional config file used to create that cluster
     config_file: str
-    # a flag indicating if the App Platform was already initialized
-    app_platform_ready: bool = False
+    # a flag indicating if the bundled CRDs were already applied to this cluster
+    crds_ready: bool = False
+    # a flag indicating if Flux was already deployed to this cluster
+    flux_ready: bool = False
 
 
 class ClusterProvider(ABC):

--- a/app_test_suite/steps/base.py
+++ b/app_test_suite/steps/base.py
@@ -35,6 +35,7 @@ class BaseTestScenariosFilteringPipeline(BuildStepsFilteringPipeline):
     KEY_CONFIG_OPTION_DEPLOY_CONFIG_FILE = "--app-tests-app-config-file"
     KEY_CONFIG_OPTION_PRE_HOOK = "--app-tests-pre-hook"
     KEY_CONFIG_OPTION_POST_HOOK = "--app-tests-post-hook"
+    KEY_CONFIG_OPTION_DEPLOY_FLUX = "--app-tests-deploy-flux"
 
     def __init__(self, pipeline: List[BuildStep], cluster_manager: ClusterManager):
         super().__init__(pipeline, self.KEY_CONFIG_GROUP_NAME)
@@ -82,6 +83,13 @@ class BaseTestScenariosFilteringPipeline(BuildStepsFilteringPipeline):
             self.KEY_CONFIG_OPTION_POST_HOOK,
             required=False,
             help="Executable run after tests complete (pass or skip). ATS_* env vars and KUBECONFIG are set.",
+        )
+        self._config_parser_group.add_argument(
+            self.KEY_CONFIG_OPTION_DEPLOY_FLUX,
+            required=False,
+            action="store_true",
+            help="Deploy Flux (CRDs and controllers) to the test cluster before deploying the chart. Required for"
+            " testing app bundles that include Flux resources like 'Kustomization' or 'HelmRelease'.",
         )
         self._cluster_manager.initialize_config(self._config_parser_group)
 

--- a/app_test_suite/steps/scenarios/simple.py
+++ b/app_test_suite/steps/scenarios/simple.py
@@ -35,6 +35,8 @@ CHART_YAML = "Chart.yaml"
 _HELM_BIN = "helm"
 _KUBECTL_BIN = "kubectl"
 _HELM_DEPLOY_TIMEOUT = "30m"
+_FLUX_NAMESPACE = "flux-system"
+_FLUX_DEPLOY_TIMEOUT = "5m"
 
 logger = logging.getLogger(__name__)
 
@@ -49,6 +51,7 @@ class SimpleTestScenario(BuildStep, ABC):
     """
 
     _CRD_DIR = "/etc/ats/crds"
+    _FLUX_MANIFEST_PATH = "/etc/ats/flux/install.yaml"
 
     def __init__(self, cluster_manager: ClusterManager, test_executor: TestExecutor):
         self._cluster_manager = cluster_manager
@@ -141,17 +144,47 @@ class SimpleTestScenario(BuildStep, ABC):
         if run_res.returncode != 0:
             raise ATSTestError(f"{stage.capitalize()}-hook '{hook_cmd}' failed with exit code {run_res.returncode}")
 
+    def _kubectl_apply(self, kube_config_path: str, target: str, error_msg: str) -> None:
+        run_res = run_and_log(
+            [_KUBECTL_BIN, f"--kubeconfig={kube_config_path}", "apply", "--server-side", "-f", target],
+            capture_output=True,
+        )  # nosec
+        if run_res.returncode != 0:
+            raise ATSTestError(f"{error_msg}:\n{run_res.stderr.decode(errors='replace')}")
+
     def _ensure_cluster_prerequisites(self, kube_config_path: str) -> None:
         logger.info(f"Applying cluster CRDs from {self._CRD_DIR}")
+        self._kubectl_apply(kube_config_path, self._CRD_DIR, "Bootstrapping CRDs on the target cluster failed")
+        logger.info("Cluster CRDs bootstrapped and ready.")
+
+    def _deploy_flux(self, kube_config_path: str) -> None:
+        if not os.path.isfile(self._FLUX_MANIFEST_PATH):
+            raise ATSTestError(
+                f"Flux deployment was requested, but the Flux manifest '{self._FLUX_MANIFEST_PATH}' doesn't exist."
+                f" The manifest is bundled in the ats container image; when running ats outside the container,"
+                f" download 'install.yaml' from a fluxcd/flux2 release and place it at that path."
+            )
+        logger.info(f"Deploying Flux from {self._FLUX_MANIFEST_PATH}")
+        self._kubectl_apply(kube_config_path, self._FLUX_MANIFEST_PATH, "Deploying Flux on the target cluster failed")
         run_res = run_and_log(
-            ["kubectl", f"--kubeconfig={kube_config_path}", "apply", "--server-side", "-f", self._CRD_DIR],
+            [
+                _KUBECTL_BIN,
+                f"--kubeconfig={kube_config_path}",
+                "--namespace",
+                _FLUX_NAMESPACE,
+                "wait",
+                "--for=condition=Available",
+                "deployment",
+                "--all",
+                f"--timeout={_FLUX_DEPLOY_TIMEOUT}",
+            ],
             capture_output=True,
         )  # nosec
         if run_res.returncode != 0:
             raise ATSTestError(
-                f"Bootstrapping CRDs on the target cluster failed:\n{run_res.stderr.decode(errors='replace')}"
+                f"Waiting for Flux controllers to become available failed:\n{run_res.stderr.decode(errors='replace')}"
             )
-        logger.info("Cluster CRDs bootstrapped and ready.")
+        logger.info("Flux deployed and ready.")
 
     def initialize_config(self, config_parser: configargparse.ArgParser) -> None:
         config_parser.add_argument(
@@ -211,9 +244,19 @@ class SimpleTestScenario(BuildStep, ABC):
         except Exception:
             raise ATSTestError("Can't establish connection to the new test cluster")
 
-        if not self._cluster_info.app_platform_ready:
+        if not self._cluster_info.crds_ready:
             self._ensure_cluster_prerequisites(self._cluster_info.kube_config_path)
-            self._cluster_info.app_platform_ready = True
+            self._cluster_info.crds_ready = True
+
+        if (
+            get_config_value_by_cmd_line_option(
+                config,
+                BaseTestScenariosFilteringPipeline.KEY_CONFIG_OPTION_DEPLOY_FLUX,
+            )
+            and not self._cluster_info.flux_ready
+        ):
+            self._deploy_flux(self._cluster_info.kube_config_path)
+            self._cluster_info.flux_ready = True
 
         try:
             if (

--- a/app_test_suite/steps/scenarios/simple.py
+++ b/app_test_suite/steps/scenarios/simple.py
@@ -150,7 +150,7 @@ class SimpleTestScenario(BuildStep, ABC):
             capture_output=True,
         )  # nosec
         if run_res.returncode != 0:
-            raise ATSTestError(f"{error_msg}:\n{run_res.stderr.decode(errors='replace')}")
+            raise ATSTestError(f"{error_msg}:\n{run_res.stderr}")
 
     def _ensure_cluster_prerequisites(self, kube_config_path: str) -> None:
         logger.info(f"Applying cluster CRDs from {self._CRD_DIR}")
@@ -181,9 +181,7 @@ class SimpleTestScenario(BuildStep, ABC):
             capture_output=True,
         )  # nosec
         if run_res.returncode != 0:
-            raise ATSTestError(
-                f"Waiting for Flux controllers to become available failed:\n{run_res.stderr.decode(errors='replace')}"
-            )
+            raise ATSTestError(f"Waiting for Flux controllers to become available failed:\n{run_res.stderr}")
         logger.info("Flux deployed and ready.")
 
     def initialize_config(self, config_parser: configargparse.ArgParser) -> None:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -137,8 +137,8 @@ def get_base_config(mocker: MockerFixture) -> Namespace:
 def get_run_and_log_result_mock(mocker: MockerFixture) -> unittest.mock.Mock:
     system_call_result_mock = mocker.Mock(name="SysCallResult")
     type(system_call_result_mock).returncode = mocker.PropertyMock(return_value=0)
-    type(system_call_result_mock).stdout = mocker.PropertyMock(return_value=b"")
-    type(system_call_result_mock).stderr = mocker.PropertyMock(return_value=b"")
+    type(system_call_result_mock).stdout = mocker.PropertyMock(return_value="")
+    type(system_call_result_mock).stderr = mocker.PropertyMock(return_value="")
     return system_call_result_mock
 
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -14,7 +14,13 @@ import app_test_suite
 from app_test_suite.cluster_manager import ClusterManager
 from app_test_suite.cluster_providers import ExternalClusterProvider
 from app_test_suite.cluster_providers.cluster_provider import ClusterInfo, ClusterType
-from app_test_suite.steps.scenarios.simple import _HELM_BIN, _HELM_DEPLOY_TIMEOUT
+from app_test_suite.steps.scenarios.simple import (
+    _FLUX_DEPLOY_TIMEOUT,
+    _FLUX_NAMESPACE,
+    _HELM_BIN,
+    _HELM_DEPLOY_TIMEOUT,
+    _KUBECTL_BIN,
+)
 
 MOCK_KUBE_CONFIG_PATH = "/nonexisting-flsdhge235/kube.config"
 MOCK_KUBE_VERSION = "1.19.1"
@@ -79,6 +85,35 @@ def assert_cluster_prerequisites_ready(kube_config_path: str) -> None:
     )
 
 
+def flux_deploy_call_args(kube_config_path: str, flux_manifest_path: str) -> list:
+    return [_KUBECTL_BIN, f"--kubeconfig={kube_config_path}", "apply", "--server-side", "-f", flux_manifest_path]
+
+
+def flux_wait_call_args(kube_config_path: str) -> list:
+    return [
+        _KUBECTL_BIN,
+        f"--kubeconfig={kube_config_path}",
+        "--namespace",
+        _FLUX_NAMESPACE,
+        "wait",
+        "--for=condition=Available",
+        "deployment",
+        "--all",
+        f"--timeout={_FLUX_DEPLOY_TIMEOUT}",
+    ]
+
+
+def assert_flux_deployed(kube_config_path: str, flux_manifest_path: str) -> None:
+    run_and_log_mock = cast(unittest.mock.Mock, app_test_suite.steps.scenarios.simple.run_and_log)
+    run_and_log_mock.assert_any_call(flux_deploy_call_args(kube_config_path, flux_manifest_path), capture_output=True)
+    run_and_log_mock.assert_any_call(flux_wait_call_args(kube_config_path), capture_output=True)
+
+
+def assert_flux_not_deployed() -> None:
+    run_and_log_mock = cast(unittest.mock.Mock, app_test_suite.steps.scenarios.simple.run_and_log)
+    assert not any("wait" in c.args[0] for c in run_and_log_mock.call_args_list)
+
+
 def assert_cluster_connection_created(kube_config_path: str) -> None:
     cast(unittest.mock.Mock, pykube.KubeConfig.from_file).assert_called_once_with(kube_config_path)
     cast(unittest.mock.Mock, app_test_suite.steps.scenarios.simple.HTTPClient).assert_called_once()
@@ -93,6 +128,7 @@ def get_base_config(mocker: MockerFixture) -> Namespace:
     config.app_tests_pre_deploy_script = ""
     config.app_tests_pre_hook = ""
     config.app_tests_post_hook = ""
+    config.app_tests_deploy_flux = False
     config.chart_file = MOCK_CHART_FILE_NAME
     config.debug = False
     return config

--- a/tests/scenarios/test_simple_scenarios.py
+++ b/tests/scenarios/test_simple_scenarios.py
@@ -1,5 +1,6 @@
 import os
 import unittest.mock
+from pathlib import Path
 from typing import Callable, Type, cast
 
 import pytest
@@ -20,6 +21,9 @@ from tests.helpers import (
     assert_helm_uninstalled,
     assert_cluster_prerequisites_ready,
     assert_cluster_connection_created,
+    assert_flux_deployed,
+    assert_flux_not_deployed,
+    flux_wait_call_args,
     get_base_config,
     get_run_and_log_result_mock,
     patch_base_test_runner,
@@ -181,4 +185,86 @@ def test_pre_hook_failure_raises(mocker: MockerFixture) -> None:
     context = {CONTEXT_KEY_CHART_YAML: {"name": REAL_CHART_APP_NAME, "version": REAL_CHART_VERSION}}
 
     with pytest.raises(ATSTestError, match="Pre-hook"):
+        runner.run(config, context)
+
+
+def _write_flux_manifest(tmp_path: Path) -> str:
+    manifest = tmp_path / "install.yaml"
+    manifest.write_text("# flux install manifest")
+    return str(manifest)
+
+
+def test_flux_deployed_when_configured(mocker: MockerFixture, tmp_path: Path) -> None:
+    flux_manifest_path = _write_flux_manifest(tmp_path)
+    mocker.patch.object(SimpleTestScenario, "_FLUX_MANIFEST_PATH", flux_manifest_path)
+    runner = _make_smoke_runner(mocker)
+    config = get_base_config(mocker)
+    config.app_tests_deploy_flux = True
+    context = {CONTEXT_KEY_CHART_YAML: {"name": REAL_CHART_APP_NAME, "version": REAL_CHART_VERSION}}
+
+    runner.run(config, context)
+
+    assert_flux_deployed(MOCK_KUBE_CONFIG_PATH, flux_manifest_path)
+    assert runner._cluster_info is not None and runner._cluster_info.flux_ready
+
+
+def test_flux_not_deployed_by_default(mocker: MockerFixture) -> None:
+    runner = _make_smoke_runner(mocker)
+    config = get_base_config(mocker)
+    context = {CONTEXT_KEY_CHART_YAML: {"name": REAL_CHART_APP_NAME, "version": REAL_CHART_VERSION}}
+
+    runner.run(config, context)
+
+    assert_flux_not_deployed()
+    assert runner._cluster_info is not None and not runner._cluster_info.flux_ready
+
+
+def test_flux_deploy_skipped_when_cluster_already_has_flux(mocker: MockerFixture, tmp_path: Path) -> None:
+    flux_manifest_path = _write_flux_manifest(tmp_path)
+    mocker.patch.object(SimpleTestScenario, "_FLUX_MANIFEST_PATH", flux_manifest_path)
+    runner = _make_smoke_runner(mocker)
+    cast(unittest.mock.Mock, runner._cluster_manager).get_cluster_for_test_type.return_value.flux_ready = True
+    config = get_base_config(mocker)
+    config.app_tests_deploy_flux = True
+    context = {CONTEXT_KEY_CHART_YAML: {"name": REAL_CHART_APP_NAME, "version": REAL_CHART_VERSION}}
+
+    runner.run(config, context)
+
+    assert_flux_not_deployed()
+
+
+def test_flux_deploy_fails_when_manifest_missing(mocker: MockerFixture, tmp_path: Path) -> None:
+    mocker.patch.object(SimpleTestScenario, "_FLUX_MANIFEST_PATH", str(tmp_path / "nonexistent.yaml"))
+    runner = _make_smoke_runner(mocker)
+    config = get_base_config(mocker)
+    config.app_tests_deploy_flux = True
+    context = {CONTEXT_KEY_CHART_YAML: {"name": REAL_CHART_APP_NAME, "version": REAL_CHART_VERSION}}
+
+    with pytest.raises(ATSTestError, match="doesn't exist"):
+        runner.run(config, context)
+
+
+def test_flux_deploy_fails_when_controllers_not_available(mocker: MockerFixture, tmp_path: Path) -> None:
+    flux_manifest_path = _write_flux_manifest(tmp_path)
+    mocker.patch.object(SimpleTestScenario, "_FLUX_MANIFEST_PATH", flux_manifest_path)
+    run_and_log_res = get_run_and_log_result_mock(mocker)
+    patch_base_test_runner(mocker, run_and_log_res)
+    patch_pytest_test_runner(mocker, run_and_log_res)
+
+    fail_res = get_run_and_log_result_mock(mocker)
+    type(fail_res).returncode = mocker.PropertyMock(return_value=1)
+
+    def side_effect(args: list[str], **kwargs: object) -> unittest.mock.Mock:
+        if args == flux_wait_call_args(MOCK_KUBE_CONFIG_PATH):
+            return fail_res
+        return run_and_log_res
+
+    mocker.patch("app_test_suite.steps.scenarios.simple.run_and_log", side_effect=side_effect)
+
+    runner = SmokeTestScenario(get_mock_cluster_manager(mocker), PytestExecutor())
+    config = get_base_config(mocker)
+    config.app_tests_deploy_flux = True
+    context = {CONTEXT_KEY_CHART_YAML: {"name": REAL_CHART_APP_NAME, "version": REAL_CHART_VERSION}}
+
+    with pytest.raises(ATSTestError, match="Flux controllers"):
         runner.run(config, context)


### PR DESCRIPTION
Closes #655.

## What changed

- New opt-in `--app-tests-deploy-flux` option (also settable as `ATS_APP_TESTS_DEPLOY_FLUX` / via `.ats/main.yaml`, like every other option). When enabled, ATS deploys Flux to the test cluster after the CRD bootstrap and before the chart under test is installed, and waits for the controllers to become `Available` (5m timeout). This makes bundles that ship Flux resources (`Kustomization`, `HelmRelease`, ...) actually reconcile during tests.
- The Flux manifest is the official `install.yaml` release asset from `fluxcd/flux2`, downloaded at image build time with a renovate-tracked version pin (same pattern as the other pinned binaries) and shipped at `/etc/ats/flux/install.yaml`. Applied with `kubectl apply --server-side`, same as the vendored CRDs. When running `ats` outside the container, the error message tells you where to place the manifest.
- Deployment happens once per test cluster and is shared across scenarios (smoke/functional/upgrade), tracked via a new `ClusterInfo.flux_ready` flag.
- Renamed the stale `ClusterInfo.app_platform_ready` flag to `crds_ready`; it has only gated the CRD bootstrap since the App Platform dependency was removed.

## Why not flux-aio

The issue suggests [flux-aio](https://github.com/stefanprodan/flux-aio), but it is only installable through `timoni` + CUE bundles, which would add a new binary and toolchain to the image. The upstream `install.yaml` is a plain, signed, renovate-trackable release asset that fits the existing vendored-manifest pattern, and full Flux on a kind cluster is well within the resource budget of a test run.