### PR TITLE
fix: report kubectl stderr as text on CRD bootstrap failure

### DIFF
--- a/app_test_suite/steps/scenarios/simple.py
+++ b/app_test_suite/steps/scenarios/simple.py
@@ -148,9 +148,7 @@ class SimpleTestScenario(BuildStep, ABC):
             capture_output=True,
         )  # nosec
         if run_res.returncode != 0:
-            raise ATSTestError(
-                f"Bootstrapping CRDs on the target cluster failed:\n{run_res.stderr.decode(errors='replace')}"
-            )
+            raise ATSTestError(f"Bootstrapping CRDs on the target cluster failed:\n{run_res.stderr}")
         logger.info("Cluster CRDs bootstrapped and ready.")
 
     def initialize_config(self, config_parser: configargparse.ArgParser) -> None:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -101,8 +101,8 @@ def get_base_config(mocker: MockerFixture) -> Namespace:
 def get_run_and_log_result_mock(mocker: MockerFixture) -> unittest.mock.Mock:
     system_call_result_mock = mocker.Mock(name="SysCallResult")
     type(system_call_result_mock).returncode = mocker.PropertyMock(return_value=0)
-    type(system_call_result_mock).stdout = mocker.PropertyMock(return_value=b"")
-    type(system_call_result_mock).stderr = mocker.PropertyMock(return_value=b"")
+    type(system_call_result_mock).stdout = mocker.PropertyMock(return_value="")
+    type(system_call_result_mock).stderr = mocker.PropertyMock(return_value="")
     return system_call_result_mock
 
 


### PR DESCRIPTION
`run_and_log` runs subprocesses with `text=True`, so `CompletedProcess.stderr` is already a `str`. The `.decode(errors='replace')` in the CRD bootstrap error path raised `AttributeError: 'str' object has no attribute 'decode'` whenever `kubectl apply` failed, masking the real error. Found while testing #655 work against a kind cluster whose Kubernetes version rejected a vendored CRD.

Test mocks now return `str` for stdout/stderr to match the `text=True` contract.