### PR TITLE
fix: keep release version in docker-build-ver via IMG_VER

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), following
 - `--app-tests-skip-app-delete` now prevents teardown of the deployed chart. It was previously ignored whenever the chart had been deployed (only honored when `--app-tests-skip-app-deploy` was also set).
 - The `versions` command no longer fails with `apptestctl: command not found` after the `apptestctl` binary was dropped from the image.
 - Errors raised while running a test scenario now preserve the original exception as the cause and no longer report every failure as an "Application deployment failed", so pre-hook, test, and post-hook failures are attributed correctly.
+- `make release` no longer bakes the wrong version into the released image and commit. The `release` target's `docker-test` prerequisite pulled in `docker-build-ver`, which overwrote `app_test_suite/version.py` (already stamped with the release tag by `release_ver_to_code`) with the dev version `<latest-tag>-<commit>`. `docker-build-ver` now stamps `IMG_VER`, which equals the dev version for normal builds and the release tag during a release.
 
 ### Removed
 

--- a/Makefile.ats.mk
+++ b/Makefile.ats.mk
@@ -43,7 +43,7 @@ docker-build-image:
 	docker build . -t ${IMG}:latest -t ${IMG}:${IMG_VER}
 
 docker-build-ver:
-	echo "build_ver = \"${VER}-${COMMIT}\"" > app_test_suite/version.py
+	echo "build_ver = \"${IMG_VER}\"" > app_test_suite/version.py
 
 # Push the docker image
 docker-push: docker-build


### PR DESCRIPTION
## What

`make release` was writing `app_test_suite/version.py` twice — first the correct release tag, then overwriting it with a stale dev version. The released image and the release commit ended up carrying the wrong `build_ver` (e.g. `v0.15.0-<commit>` instead of `v1.0.0-rc.1`).

## Why

`release: release_ver_to_code docker-test docker-build-image` builds prerequisites left-to-right:

1. `release_ver_to_code` stamps `version.py` with `${TAG}` (correct) and sets `IMG_VER := ${TAG}`.
2. `docker-test` transitively pulls in `docker-build-ver` (`docker-test → docker-build-test → docker-build → docker-build-ver`), whose recipe **unconditionally** rewrote `version.py` with the dev stamp `${VER}-${COMMIT}`, clobbering the release stamp.

## Fix

`docker-build-ver` now stamps `${IMG_VER}` instead of `${VER}-${COMMIT}`:

- `IMG_VER` defaults to `${VER}-${COMMIT}`, so normal `make docker-build` / `docker-push` / `all` are unchanged.
- During a release, `release_ver_to_code` has already set `IMG_VER := ${TAG}`, so the release stamp survives.

## Verification

- Dev path: `make docker-build-ver` still writes `build_ver = "v0.15.0-<commit>"`.
- Release path: `TAG=v1.0.0-rc.1 make release_ver_to_code docker-build-ver` now leaves `build_ver = "v1.0.0-rc.1"` (both echoes write the tag; previously the second clobbered it).

The sibling `app-build-suite` was checked and is not affected — it has no `docker-build-ver` target and runs `release_ver_to_code` last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)