### PR TITLE
docs: test-time controllers bootstrap specs

### DIFF
--- a/docs/specs/ats-test-time-controllers.md
+++ b/docs/specs/ats-test-time-controllers.md
@@ -9,7 +9,8 @@
 > presence policy, and lifecycle is defined by the contract and only *applied* here — this
 > document does not redefine it.
 >
-> ATS is the consuming tool with tool id **`ats`**, so it reads the `config.ats` key.
+> ATS is the consuming harness with id **`ats`**, so it reads its own entry (the one with
+> `name: ats`) in each controller's `harness[]` list.
 
 ## Problem Statement
 
@@ -62,9 +63,9 @@ controllers → deploy the chart under test.
 - **Skip.** `--skip-controllers` (env `ATS_SKIP_CONTROLLERS`, store-true) bootstraps no
   controllers even if the file exists (ATS logs that it is skipping). Useful when the target
   cluster is already fully provisioned, or for debugging.
-- **Per-tool values.** ATS uses the `config.ats` key of each controller entry (per the
-  contract). The named file is resolved relative to the declaration file's directory and passed
-  to Helm as `--values`, layering over the chart's defaults.
+- **Per-harness values.** ATS uses its own `harness[]` entry (the one with `name: ats`) of each
+  controller (per the contract). Its `valuesFile` is resolved relative to the declaration file's
+  directory and passed to Helm as `--values`, layering over the chart's defaults.
 - **No file / no `controllers` / empty list** → ATS bootstraps nothing and proceeds exactly as
   today (full backward compatibility for the many charts with no `.apptest/config.yaml`).
 
@@ -109,7 +110,8 @@ CLIs are added):
 
 - `helm upgrade --install <release_name> <chart_ref> --version "<semver>" --namespace
   <namespace> --create-namespace --wait --timeout <install_timeout>`, plus `--values <file>`
-  when a `config.ats` file is present, run with `KUBECONFIG` pointed at the target cluster.
+  when ATS's `harness[]` entry names a `valuesFile`, run with `KUBECONFIG` pointed at the
+  target cluster.
 - Passing `semver` straight to Helm's `--version` gives version selection identical to the
   contract's Flux/Masterminds semantics (Helm uses Masterminds/semver v3), with no
   reimplementation of range matching in Python.
@@ -122,7 +124,7 @@ same way `ClusterManager` is:
 
 - **`pre_run`** — parse and validate `.apptest/config.yaml`: resolve the declaration, reject
   unknown controller names against the registry, reject entries missing `name`/`semver`, and
-  reject `config.ats` values that name a missing file or a non-`.yaml` file. All of this happens
+  reject an ATS `harness` entry whose `valuesFile` is missing or not `.yaml`. All of this happens
   before any cluster mutation, so a misconfigured suite fails fast (mirrors how other ATS config
   is validated in `pre_run`).
 - **`run` / bootstrap** — for each declared controller, in list order: detect, then either
@@ -152,11 +154,11 @@ same way `ClusterManager` is:
    that ATS bootstraps exactly those and nothing else.
 3. As an ATS user, I want charts with no `.apptest/config.yaml` to behave exactly as before, so
    that this feature does not disrupt existing suites.
-4. As an ATS user, I want to provide ATS-specific install values via `config.ats`, so that a
-   controller is tuned for the kind of cluster ATS runs against.
-5. As an ATS user, I want a controller with no `config.ats` entry to install with chart defaults,
-   so that I only write values when I need to.
-6. As an ATS user, I want my `config.ats` values layered over the chart defaults, so that I
+4. As an ATS user, I want to provide ATS-specific install values via my `harness` entry, so that
+   a controller is tuned for the kind of cluster ATS runs against.
+5. As an ATS user, I want a controller with no ATS `harness` entry to install with chart
+   defaults, so that I only write values when I need to.
+6. As an ATS user, I want my `harness`-entry values layered over the chart defaults, so that I
    override only what I need.
 7. As an ATS user, I want a clear pre-run error if I reference a missing or misnamed values file,
    so that I fail before my cluster is touched.
@@ -196,13 +198,13 @@ same way `ClusterManager` is:
   real providers in v1, populated by explicit imports later), and a `ControllerManager`.
 - `ControllerManager` mirrors `ClusterManager`: constructed in the entry point, wired into the
   scenarios, validating in `pre_run`, bootstrapping (once) in `run`.
-- ATS reads the `config.ats` key; tool id is `ats` (see the
-  [contract's tool-id table](./test-time-controllers-contract.md#tool-ids)).
+- ATS reads its own `harness[]` entry (`name: ats`); the harness id `ats` is allocated in the
+  [RFC](https://github.com/giantswarm/rfc/pull/153).
 - Declaration discovery: single `.apptest/config.yaml` relative to CWD; overridable via
   `--controllers-config-file` / `ATS_CONTROLLERS_CONFIG_FILE`; bootstrap skippable via
   `--skip-controllers` / `ATS_SKIP_CONTROLLERS`.
 - Install via the bundled Helm binary: `helm upgrade --install ... --version "<semver>" --wait
-  --timeout <10m default> [--values <config.ats file>]`, charts from the Giant Swarm catalog.
+  --timeout <10m default> [--values <ATS harness valuesFile>]`, charts from the Giant Swarm catalog.
 - `semver` is passed to Helm `--version` for Masterminds-parity range resolution.
 - Default presence detection reads Helm release metadata and returns the installed chart version;
   overridable per provider. Version comparison basis is the chart version at both detect and
@@ -230,12 +232,12 @@ errors are raised — not on provider internals. Confirmed seams:
   present-in-range / present-out-of-range) via mocked `run_and_log` return values.
 - **Config validation** — drive `ControllerManager.pre_run` against a real `.apptest/config.yaml`
   written into a `tmp_path` (as `tests/test_executor_detection.py` does), asserting parse results
-  and validation errors (unknown name, missing `name`/`semver`, missing/mis-extensioned
-  `config.ats` file).
+  and validation errors (unknown name, missing `name`/`semver`, missing/mis-extensioned ATS
+  `harness` values file).
 - **Registry** — register a **fake `Controller` subclass** in the test to exercise the base class
   and manager, since v1 ships no real providers.
 
-Cases to cover: no-file/empty no-op; unknown-name error; missing/bad `config.ats` errors; order
+Cases to cover: no-file/empty no-op; unknown-name error; missing/bad `harness` values-file errors; order
 preservation; detect→install vs detect→skip vs out-of-range→error; values-file layering present
 vs absent; once-per-run across scenarios; skip flag; config-file override.
 
@@ -247,7 +249,7 @@ vs absent; once-per-run across scenarios; skip flag; config-file override.
 - Upgrading/downgrading or uninstalling controllers.
 - A global install-timeout option, filesystem provider auto-discovery, or external
   entry-point plugins.
-- Per-cluster-type selection among multiple ATS values sets (single `config.ats` file per
+- Per-cluster-type selection among multiple ATS values sets (single ATS `valuesFile` per
   controller in v1).
 
 ## Further Notes
@@ -257,6 +259,6 @@ vs absent; once-per-run across scenarios; skip flag; config-file override.
   this is the intended, contract-specified behaviour.
 - The design intentionally keeps the door open (via provider-owned CRDs and `pre_install`) to
   later folding CRD-only needs into providers and shrinking the `--cluster-crds` bundle.
-- See the [tool-independent contract](./test-time-controllers-contract.md) for the authoritative
-  definition of the declaration schema, version semantics, ordering, presence policy, and
-  lifecycle that this document applies.
+- See the [app-testing contract RFC](https://github.com/giantswarm/rfc/pull/153) (and its local
+  [summary](./test-time-controllers-contract.md)) for the authoritative definition of the
+  declaration schema, version semantics, ordering, presence policy, and lifecycle this applies.

--- a/docs/specs/ats-test-time-controllers.md
+++ b/docs/specs/ats-test-time-controllers.md
@@ -1,0 +1,262 @@
+# Spec: Test-Time Controllers in app-test-suite (ATS)
+
+> Status: draft · Scope: app-test-suite implementation
+>
+> This document specifies how app-test-suite (ATS) implements the tool-independent
+> [Test-Time Controllers Bootstrap Contract](./test-time-controllers-contract.md). It defines
+> ATS-specific behaviour: configuration surface, the provider framework, pipeline placement, and
+> testing. Everything about the shared `.apptest/config.yaml` schema, version semantics, ordering,
+> presence policy, and lifecycle is defined by the contract and only *applied* here — this
+> document does not redefine it.
+>
+> ATS is the consuming tool with tool id **`ats`**, so it reads the `config.ats` key.
+
+## Problem Statement
+
+ATS tests a Helm chart on a Kubernetes cluster the user provides. Some charts under test create
+custom resources (a Flux `Kustomization`, an Argo CD `Application`, an `ExternalSecret`, …) that
+are inert unless a matching controller is running on the test cluster to reconcile them. Today
+ATS only applies a static bundle of **CRDs** to the cluster (via `--cluster-crds`); it never runs
+any controller. So for these charts the CRs are accepted but never processed, the chart never
+becomes functional, and the tests cannot validate real behaviour.
+
+At the same time, controllers are expensive to deploy, and only some charts need any given one.
+ATS must not deploy controllers a chart does not need, and must not try to guess which ones a
+chart needs.
+
+## Solution
+
+ATS implements the [contract](./test-time-controllers-contract.md): it reads the chart test
+suite's `.apptest/config.yaml`, and during cluster preparation it ensures each declared
+controller is present on the target cluster at a version satisfying the declared `semver`,
+before the chart under test is deployed.
+
+ATS provides a small **provider framework**: a `Controller` base class plus a registry, so a
+controller is added by writing a short provider class and registering it — without touching the
+manager, pipeline, or any other provider. A `ControllerManager` (mirroring the existing
+`ClusterManager`) validates the declaration up front and performs the bootstrap once per run.
+
+This first deliverable ships the **framework only** — no concrete providers. Concrete providers
+already exist elsewhere and will be synced into ATS later; until then, a suite that declares a
+controller fails fast with an "unknown controller" error, which is the contract-specified
+behaviour for an unregistered name.
+
+## Relationship to the existing CRD bootstrap
+
+ATS already bootstraps a static bundle of CRDs to the cluster via `--cluster-crds`
+(`kubectl apply --server-side`), applied once per run. This feature is **additive**: it does not
+change or remove that CRD bundle. The `Controller` base class is, however, designed so a provider
+*could* own the CRDs it needs (a controller's Helm chart typically installs its own CRDs), with
+an eye toward eventually shrinking or retiring the unconditional CRD bundle in favour of
+per-need providers. That convergence is **out of scope** here.
+
+Ordering in the cluster-preparation phase is: apply the `--cluster-crds` bundle → bootstrap
+controllers → deploy the chart under test.
+
+## Configuration surface
+
+- **Declaration file discovery.** ATS reads the single `.apptest/config.yaml` relative to the
+  current working directory.
+- **Override.** `--controllers-config-file` (env `ATS_CONTROLLERS_CONFIG_FILE`) overrides the
+  path to the declaration file.
+- **Skip.** `--skip-controllers` (env `ATS_SKIP_CONTROLLERS`, store-true) bootstraps no
+  controllers even if the file exists (ATS logs that it is skipping). Useful when the target
+  cluster is already fully provisioned, or for debugging.
+- **Per-tool values.** ATS uses the `config.ats` key of each controller entry (per the
+  contract). The named file is resolved relative to the declaration file's directory and passed
+  to Helm as `--values`, layering over the chart's defaults.
+- **No file / no `controllers` / empty list** → ATS bootstraps nothing and proceeds exactly as
+  today (full backward compatibility for the many charts with no `.apptest/config.yaml`).
+
+## Provider framework
+
+### `Controller` base class
+
+A data-driven base class in `app_test_suite/controllers/` implements the generic
+bootstrap logic once; a concrete controller is mostly declaration. Expected surface (final names
+settled in implementation):
+
+- **Declarative attributes:** `name` (tool-neutral identifier, also the registry key),
+  `chart_ref` (a Giant Swarm catalog OCI chart reference, e.g.
+  `oci://gsoci.azurecr.io/giantswarm/<chart>`), `namespace`, `release_name`, and an
+  `install_timeout` default of `10m`.
+- **Overridable hooks (default implementations provided):**
+  - `pre_install(cluster)` — arbitrary setup before install (e.g. create a `Role`/`RoleBinding`,
+    apply prerequisite manifests). Default: no-op.
+  - `post_install(cluster)` — extra work / readiness after install (e.g. wait for a webhook or a
+    CRD to become established). Default: no-op.
+  - controller **detection** — returns the installed chart version on the cluster, or "absent".
+    Default implementation reads Helm release metadata (`helm list -o json`, filtered to the
+    provider's namespace/release). Overridable for controller-aware detection (e.g. a controller
+    the cluster came with, installed by other means).
+  - `values(...)` / readiness — overridable for the odd controller.
+
+Adding a controller is therefore roughly: subclass `Controller`, set `name` / `chart_ref` /
+`namespace` / `release_name`, optionally override a hook — about six lines plus registration.
+
+### Registration
+
+The base class registers every subclass into a name-keyed registry via `__init_subclass__`.
+Built-in providers live under `app_test_suite/controllers/providers/` and are made active by an
+explicit one-line import in that package. Adding a provider does not require changes to the
+manager, the registry, or the pipeline. (No filesystem auto-discovery and no external
+entry-point plugins in this iteration.)
+
+### Install mechanics
+
+Controllers install via the Helm binary already bundled in the ATS container (no `flux`/`argo`
+CLIs are added):
+
+- `helm upgrade --install <release_name> <chart_ref> --version "<semver>" --namespace
+  <namespace> --create-namespace --wait --timeout <install_timeout>`, plus `--values <file>`
+  when a `config.ats` file is present, run with `KUBECONFIG` pointed at the target cluster.
+- Passing `semver` straight to Helm's `--version` gives version selection identical to the
+  contract's Flux/Masterminds semantics (Helm uses Masterminds/semver v3), with no
+  reimplementation of range matching in Python.
+- Charts are pulled from the **Giant Swarm charts catalog**.
+
+### `ControllerManager`
+
+A dedicated `ControllerManager`, constructed in the entry point and wired into the scenarios the
+same way `ClusterManager` is:
+
+- **`pre_run`** — parse and validate `.apptest/config.yaml`: resolve the declaration, reject
+  unknown controller names against the registry, reject entries missing `name`/`semver`, and
+  reject `config.ats` values that name a missing file or a non-`.yaml` file. All of this happens
+  before any cluster mutation, so a misconfigured suite fails fast (mirrors how other ATS config
+  is validated in `pre_run`).
+- **`run` / bootstrap** — for each declared controller, in list order: detect, then either
+  install (with `pre_install`/`post_install` and `--wait`) when absent, skip when
+  present-and-satisfies, or hard-error when present-and-violates. Sequential, each ready before
+  the next.
+
+## Pipeline placement and lifecycle
+
+- Bootstrap is invoked from the scenario cluster-preparation path (`SimpleTestScenario.run`),
+  **after** the `--cluster-crds` apply (`_ensure_cluster_prerequisites`) and **before** the
+  chart-under-test deploy.
+- Bootstrap runs **once per ATS run**, shared across the smoke → functional → upgrade scenarios.
+  This is guarded by a new flag on the shared `ClusterInfo` (analogous to the existing
+  `dependency_crds_ready`), so later scenarios do not re-run detection or install.
+- Controllers are **never uninstalled** by ATS (like the CRD bundle). Both CRDs and controllers
+  are left on the cluster so subsequent runs on the same cluster are faster.
+- A failed controller bootstrap (install, `--wait` timeout, or a provider hook) fails the run and
+  is routed through the existing `_collect_failure_diagnostics` so it dumps pod/event/log
+  diagnostics like a failed app deploy does.
+
+## User Stories
+
+1. As an ATS user testing a chart that creates Flux resources, I want ATS to run Flux on my test
+   cluster, so that the chart reaches a functional state and my tests are meaningful.
+2. As an ATS user, I want to declare the controllers my chart needs in `.apptest/config.yaml`, so
+   that ATS bootstraps exactly those and nothing else.
+3. As an ATS user, I want charts with no `.apptest/config.yaml` to behave exactly as before, so
+   that this feature does not disrupt existing suites.
+4. As an ATS user, I want to provide ATS-specific install values via `config.ats`, so that a
+   controller is tuned for the kind of cluster ATS runs against.
+5. As an ATS user, I want a controller with no `config.ats` entry to install with chart defaults,
+   so that I only write values when I need to.
+6. As an ATS user, I want my `config.ats` values layered over the chart defaults, so that I
+   override only what I need.
+7. As an ATS user, I want a clear pre-run error if I reference a missing or misnamed values file,
+   so that I fail before my cluster is touched.
+8. As an ATS user, I want a clear pre-run error if I declare a controller ATS does not know, so
+   that I understand ATS cannot yet satisfy my suite.
+9. As an ATS user, I want ATS to reuse a controller already present at a compatible version, so
+   that repeated runs on the same cluster skip the install cost.
+10. As an ATS user, I want the run to fail if a present controller's version does not satisfy my
+    `semver`, so that I am not testing against the wrong version.
+11. As an ATS user, I want ATS never to change or remove a controller already on my cluster, so
+    that a shared cluster's controllers are undisturbed.
+12. As an ATS user, I want controllers declared in a specific order to be installed in that
+    order, so that dependencies between them are respected.
+13. As an ATS user, I want a `--skip-controllers` switch, so that I can bypass bootstrap on an
+    already-provisioned cluster or while debugging.
+14. As an ATS user, I want a `--controllers-config-file` override, so that I can point ATS at a
+    declaration file in a non-default location.
+15. As an ATS user, I want controllers bootstrapped only once per run across
+    smoke/functional/upgrade phases, so that I do not pay the cost repeatedly.
+16. As an ATS user, I want a failed controller bootstrap to emit cluster diagnostics, so that I
+    can debug why it did not come up.
+17. As a controller-provider author, I want to add a provider by writing a short class and
+    registering it, so that I do not touch the manager, pipeline, or other providers.
+18. As a controller-provider author, I want pre-install and post-install hooks, so that I can
+    create RBAC or wait for webhooks/CRDs around the install.
+19. As a controller-provider author, I want a default helm-release detection I can override, so
+    that the common case is free but I can implement controller-aware detection when needed.
+20. As an ATS maintainer, I want the framework shipped without concrete providers, so that we can
+    land it now and sync the existing providers in later.
+21. As an ATS maintainer, I want this feature to leave the existing `--cluster-crds` bundle
+    untouched, so that the change is additive and low-risk.
+
+## Implementation Decisions
+
+- New package `app_test_suite/controllers/` containing: the `Controller` base class, a
+  name-keyed registry (populated via `__init_subclass__`), a `providers/` subpackage (empty of
+  real providers in v1, populated by explicit imports later), and a `ControllerManager`.
+- `ControllerManager` mirrors `ClusterManager`: constructed in the entry point, wired into the
+  scenarios, validating in `pre_run`, bootstrapping (once) in `run`.
+- ATS reads the `config.ats` key; tool id is `ats` (see the
+  [contract's tool-id table](./test-time-controllers-contract.md#tool-ids)).
+- Declaration discovery: single `.apptest/config.yaml` relative to CWD; overridable via
+  `--controllers-config-file` / `ATS_CONTROLLERS_CONFIG_FILE`; bootstrap skippable via
+  `--skip-controllers` / `ATS_SKIP_CONTROLLERS`.
+- Install via the bundled Helm binary: `helm upgrade --install ... --version "<semver>" --wait
+  --timeout <10m default> [--values <config.ats file>]`, charts from the Giant Swarm catalog.
+- `semver` is passed to Helm `--version` for Masterminds-parity range resolution.
+- Default presence detection reads Helm release metadata and returns the installed chart version;
+  overridable per provider. Version comparison basis is the chart version at both detect and
+  install time.
+- Presence policy per the contract: absent → install; present-and-satisfies → skip;
+  present-and-violates → hard error (no upgrade/downgrade/replace).
+- Per-provider `install_timeout` (default `10m`); no global timeout knob in v1.
+- Bootstrap runs once per run, guarded by a new flag on `ClusterInfo` (parallel to
+  `dependency_crds_ready`); pipeline order is CRD bundle → controllers → app deploy.
+- Controllers are install-only (no teardown). Install failures route through
+  `_collect_failure_diagnostics`.
+- The existing `--cluster-crds` bundle is unchanged (additive design).
+- No `flux`/`argo` CLIs added to the container; Helm-only.
+
+## Testing Decisions
+
+Tests follow the existing repo pattern (`tests/helpers.py`, `tests/scenarios/`), asserting on
+external behaviour — what gets installed, in what order, with what configuration, and which
+errors are raised — not on provider internals. Confirmed seams:
+
+- **Primary seam — `run_and_log`** in the controllers module. All `helm`/`kubectl` calls
+  (install with `--version <semver> --wait`, helm-release detection via `helm list -o json`,
+  `kubectl apply` for `pre_install` manifests) route through the same `run_and_log` the scenario
+  tests already mock. Tests assert on the argv and simulate cluster state (absent /
+  present-in-range / present-out-of-range) via mocked `run_and_log` return values.
+- **Config validation** — drive `ControllerManager.pre_run` against a real `.apptest/config.yaml`
+  written into a `tmp_path` (as `tests/test_executor_detection.py` does), asserting parse results
+  and validation errors (unknown name, missing `name`/`semver`, missing/mis-extensioned
+  `config.ats` file).
+- **Registry** — register a **fake `Controller` subclass** in the test to exercise the base class
+  and manager, since v1 ships no real providers.
+
+Cases to cover: no-file/empty no-op; unknown-name error; missing/bad `config.ats` errors; order
+preservation; detect→install vs detect→skip vs out-of-range→error; values-file layering present
+vs absent; once-per-run across scenarios; skip flag; config-file override.
+
+## Out of Scope
+
+- Shipping concrete providers (flux, argo, external-secrets, …) — synced in a later change.
+- Sharing provider *code* with apptest-framework (only the declaration file is shared).
+- Changing, reducing, or retiring the existing `--cluster-crds` bundle.
+- Upgrading/downgrading or uninstalling controllers.
+- A global install-timeout option, filesystem provider auto-discovery, or external
+  entry-point plugins.
+- Per-cluster-type selection among multiple ATS values sets (single `config.ats` file per
+  controller in v1).
+
+## Further Notes
+
+- Because the framework ships without providers, the first user-visible effect is that a suite
+  declaring any controller fails with an "unknown controller" error until providers are synced —
+  this is the intended, contract-specified behaviour.
+- The design intentionally keeps the door open (via provider-owned CRDs and `pre_install`) to
+  later folding CRD-only needs into providers and shrinking the `--cluster-crds` bundle.
+- See the [tool-independent contract](./test-time-controllers-contract.md) for the authoritative
+  definition of the declaration schema, version semantics, ordering, presence policy, and
+  lifecycle that this document applies.

--- a/docs/specs/test-time-controllers-contract.md
+++ b/docs/specs/test-time-controllers-contract.md
@@ -1,320 +1,50 @@
-# Spec: Test-Time Controllers Bootstrap Contract
+# Test-Time Controllers Bootstrap Contract
 
 > Status: draft · Scope: tool-independent contract
 >
-> This document defines a **tool-independent** contract for declaring and bootstrapping
-> the Kubernetes controllers a chart's test suite needs at test time. It is written to be
-> implemented by more than one test tool. It deliberately contains **no** concepts, option
-> names, file layouts, or behaviours specific to any single tool.
->
-> For the concrete application of this contract to app-test-suite (ATS), see the companion
-> spec: [ATS Test-Time Controllers](./ats-test-time-controllers.md).
+> **The authoritative, harness-neutral contract now lives in the Giant Swarm
+> [app-testing contract RFC](https://github.com/giantswarm/rfc/pull/153)**
+> (`app-testing-contract/README.md`, section "Prerequisite controllers"). This page is a
+> summary and pointer; it will be reduced to a bare link once that RFC merges. For how
+> app-test-suite implements the contract, see
+> [ATS Test-Time Controllers](./ats-test-time-controllers.md).
 
-## Problem Statement
+## Summary
 
-A Helm chart under test frequently creates custom resources (CRs) — for example a Flux
-`Kustomization`, an Argo CD `Application`, or an `ExternalSecret` — that only become
-meaningful when a matching **controller** is running on the test cluster to reconcile them.
-Without that controller, the API server may accept the CR (if its CRD is present) but nothing
-acts on it, so the chart never reaches a functional state and the tests cannot validate real
-behaviour.
+A chart's test suite declares, explicitly, the controllers it needs so that any conforming test
+harness (app-test-suite, apptest-framework) bootstraps them on the target cluster before the chart
+under test is deployed. There is no auto-detection — declaring is the opt-in. Controllers are
+named, version-ranged, installed in declared order, reused when already present at a compatible
+version, and never uninstalled. The declaration is shared across harnesses; the provider code that
+installs a named controller is each harness's own.
 
-Which controllers a chart needs is specific to that chart. Only a subset of charts need any
-given controller, and deploying controllers is expensive (time and cluster resources).
-Deploying every possible controller for every chart is wasteful; guessing which ones a chart
-needs from its contents is fragile and flaky.
-
-Different test tools consume the same chart test suites. A chart declares its controller needs
-once; every tool that runs that suite must be able to read the same declaration and bootstrap
-the same set of controllers, even though each tool targets a different kind of cluster and may
-need different install-time configuration.
-
-## Solution
-
-A chart's test suite declares, **explicitly**, the exact set of controllers it needs, in a
-single well-known file that is part of the test suite. Any conforming test tool reads that file
-and, during its cluster-preparation phase, ensures each declared controller is present on the
-target cluster at an acceptable version before the chart is deployed and tested.
-
-- Declaration is **opt-in and explicit** — no auto-detection. A chart that declares nothing
-  gets nothing bootstrapped.
-- The declaration is **tool-neutral**: it names controllers and version ranges, and it carries
-  per-tool install configuration under tool-namespaced keys, so multiple tools can share one
-  file.
-- Each conforming tool owns its own **controller provider** implementations (how a named
-  controller is installed, detected, and made ready). The file is the shared contract; the
-  provider code is not.
-- A tool installs only the declared controllers, in declared order, and reuses controllers that
-  are already present.
-
-## Terminology
-
-- **Controller** — a Kubernetes workload (and its CRDs/RBAC) that reconciles a class of custom
-  resources (e.g. Flux, Argo CD, External Secrets).
-- **Controller name** — the stable, tool-neutral identifier of a controller (e.g. `flux`,
-  `argo`, `external-secrets`) used in the declaration and to look up a provider.
-- **Provider** — a tool-side implementation that knows how to detect, install, and ready a
-  particular controller. Providers are owned by each tool, not by this contract.
-- **Consuming tool** — a test tool that implements this contract (reads the declaration and
-  bootstraps controllers). Each consuming tool has a short **tool id** (see
-  [Tool ids](#tool-ids)).
-- **Target cluster** — the pre-existing cluster the consuming tool prepares and runs tests on.
-- **Test suite** — the chart-specific test assets, of which the declaration file is a part.
-
-## The declaration file
-
-### Location
-
-The declaration lives at `.apptest/config.yaml` within the test suite. The `.apptest/`
-directory is the shared, tool-neutral home for cross-tool testing declarations; this contract
-defines the `controllers` section of `config.yaml`. Other sections may be added by future
-contracts and must be ignored by a tool that does not understand them.
-
-How a tool discovers, resolves, or overrides the path to this file is tool-specific and out of
-scope for this contract. What is fixed is the filename and the schema below.
-
-### Schema
-
-```yaml
-controllers:
-  - name: <controller-name>        # required, string
-    semver: <version-range>        # required, string (see "Version selection")
-    config:                        # optional, mapping of tool id -> values file name
-      <tool-id>: <filename.yaml>   # optional per tool id
-      ...
-  - ...
-```
-
-- `controllers` — an ordered list. **Order is significant** (see
-  [Install ordering](#install-ordering)).
-- `name` — **required**. The tool-neutral controller name. If a consuming tool has no provider
-  registered for this name, that is a hard error (see [Error handling](#error-handling)).
-- `semver` — **required**. A version range (see [Version selection](#version-selection)).
-- `config` — **optional**. A mapping keyed by **tool id**. Each value is the file name of a
-  tool-specific install-configuration (values) file for this controller. See
-  [Per-tool configuration](#per-tool-configuration).
-
-A missing, empty, or absent `controllers` section means **no controllers are declared** and a
-conforming tool bootstraps nothing.
-
-### Tool ids
-
-Each consuming tool has a short, unique **tool id** used as its key under `config`. This keeps
-the shared file tool-neutral: a tool reads only its own key and ignores the others.
-
-Tool ids are allocated by this contract to avoid collisions. Currently allocated:
-
-- `ats` — app-test-suite (see [ATS spec](./ats-test-time-controllers.md))
-- `atf` — apptest-framework
-
-New consuming tools must allocate a new tool id here before using it.
-
-### Per-tool configuration
-
-The set of controllers a chart needs is tool-neutral, but the *configuration* used to install a
-controller often differs per tool, because each tool targets a different kind of cluster (for
-example a small local cluster vs. a full production-like cluster). Those install-time values
-therefore belong to the tool, not to the shared list of names.
-
-- Per-controller configuration is **optional**. If an entry has no `config` mapping, or no key
-  for the current tool's id, the controller is installed with its **default** configuration.
-- When present, `config.<tool-id>` names a **values file** authored by the test-suite author
-  and shipped inside the test suite (alongside the declaration file).
-- Each value **must** be a full file name ending in `.yaml`.
-- The named file is resolved relative to the declaration file's directory.
-- A conforming tool applies the file as install-time configuration **layered over the
-  controller's defaults** (i.e. an overlay, not a full replacement).
-- If `config.<tool-id>` names a file that does not exist, or a value that does not end in
-  `.yaml`, that is a hard error (see [Error handling](#error-handling)).
-
-Example:
+The declaration lives in the shared `.apptest/config.yaml`:
 
 ```yaml
 controllers:
   - name: flux
     semver: ">=2.0.0 <3.0.0"
-    config:
-      ats: flux-small.yaml      # used by app-test-suite
-      atf: flux-full.yaml       # used by apptest-framework
+    harness:                       # optional per-harness install values files
+      - name: ats                  # ATS reads its own entry
+        valuesFile: flux-small.yaml
+      - name: atf                  # apptest-framework reads its own entry
+        valuesFile: flux-full.yaml
   - name: external-secrets
     semver: "0.x"
-    # no config -> each tool installs with the controller's default configuration
 ```
 
-## Behaviour
+- `name` (required) — harness-neutral controller id; unknown to the running harness → hard error.
+- `semver` (required) — a version range with Masterminds/semver v3 semantics (as used by Flux
+  `OCIRepository` and Helm `--version`), resolved to the highest satisfying version.
+- `harness[]` (optional) — per-harness install values files, listed by harness `name` (not keyed
+  by it). Each `valuesFile` ends in `.yaml`, resolves next to `config.yaml` under `.apptest/`, and
+  layers over the controller's defaults. No entry for the running harness → chart defaults; a named
+  file that is missing or not `.yaml` → hard error.
 
-### Version selection
+Presence policy: absent → install; present-and-satisfies-`semver` → reuse; present-but-out-of-range
+→ hard error (a conforming harness never upgrades, downgrades, or removes a controller it finds).
 
-`semver` is a **version range**, interpreted with the same semantics as Flux
-`OCIRepository` semver matching and Helm's `--version` constraint — i.e. the
-Masterminds/semver v3 range grammar. Examples: `1.2.x`, `>=1.0.0 <2.0.0`, `~1.2.3`, `^1.2.3`,
-`*`. Pre-releases are excluded unless the range explicitly names a pre-release. See
-<https://fluxcd.io/flux/components/source/ocirepositories/#semver-example>.
-
-A conforming tool resolves the range to the **highest available version that satisfies it** and
-installs that version. How available versions are enumerated (registry, chart repository, etc.)
-is provider-defined.
-
-### Install ordering
-
-Controllers are bootstrapped **sequentially, in the order they appear** in the `controllers`
-list. A controller must be fully installed **and ready** before the next controller in the list
-is started. Tools must not reorder or parallelise the list. Authors may therefore rely on order
-to express dependencies between controllers.
-
-### Presence detection and version policy
-
-Before installing a controller, a conforming tool must determine whether an acceptable instance
-is **already present** on the target cluster, and reuse it rather than reinstalling:
-
-- The provider reports the **installed version** of the controller on the target cluster, or
-  reports that it is **absent**. The version reported at detection time and the version selected
-  at install time are compared on the **same basis** (the chart version), so they are directly
-  comparable.
-- **Absent** → the tool installs the controller (resolving `semver` as above), then waits for it
-  to be ready.
-- **Present and the installed version satisfies `semver`** → the tool reuses it and skips
-  installation.
-- **Present but the installed version does not satisfy `semver`** → **hard error**. A conforming
-  tool must **not** upgrade, downgrade, or replace a controller it finds already present; the
-  mismatch fails the run so the operator can resolve it. (The rationale: the target cluster is
-  not owned by the tool, and silently changing an existing controller could break other
-  workloads.)
-
-### Provider setup hooks
-
-A controller install is not always a single package install. A provider may need to perform
-setup **before** installing (for example creating a `Role`/`RoleBinding` or applying prerequisite
-manifests) and additional work or readiness checks **after** installing (for example waiting for
-a webhook or a freshly-installed CRD to become established). The contract therefore requires that
-a provider be able to run arbitrary **pre-install** and **post-install** steps around the install,
-in addition to the declarative common case.
-
-### Readiness
-
-"Ready" means the controller's workloads report healthy **and** any provider-defined
-post-install readiness checks have passed. A controller is only considered bootstrapped once it
-is ready. Because installs are sequential, the readiness of controller *N* is guaranteed before
-controller *N+1* begins.
-
-### Idempotency and lifecycle
-
-- Bootstrapping is performed **once per target cluster per run**, shared across all test phases
-  in that run.
-- Bootstrapped controllers are **installed only — never uninstalled** by the tool. They are
-  treated as durable cluster infrastructure. Leaving them in place makes subsequent runs on the
-  same cluster faster and avoids removing something another chart or run may depend on.
-
-### Error handling
-
-The following are **hard errors** that must be surfaced clearly:
-
-- A declared `name` has no registered provider in the consuming tool.
-- A declaration entry is missing a required field (`name` or `semver`).
-- `config.<tool-id>` names a non-existent file or a value not ending in `.yaml`.
-- `semver` resolves to no available version.
-- A controller is present but its installed version does not satisfy `semver`.
-- An install, readiness wait, or provider setup hook fails.
-
-Configuration-level errors (the first three) should be detected as early as possible — before
-any cluster changes are made — so a misconfigured suite fails fast. Where exactly a tool
-performs this validation is tool-specific.
-
-## User Stories
-
-1. As a chart/test-suite author, I want to declare the controllers my chart needs in one file,
-   so that any test tool can bootstrap them consistently.
-2. As a chart author, I want to declare a controller by name and version range, so that I get a
-   compatible version without pinning an exact release.
-3. As a chart author, I want controllers I did not declare to never be installed, so that my
-   test runs stay fast and cheap.
-4. As a chart author, I want no controller auto-detection, so that my test setup is explicit and
-   not flaky.
-5. As a chart author, I want to declare controllers in a specific order, so that a controller
-   that depends on another is bootstrapped after it.
-6. As a chart author, I want to optionally provide per-tool install configuration for a
-   controller, so that the same controller can be tuned for a small cluster in one tool and a
-   full cluster in another.
-7. As a chart author, I want a controller with no per-tool configuration to install with sensible
-   defaults, so that I only write configuration when I actually need to override something.
-8. As a chart author, I want my per-tool values file to be layered over the controller's
-   defaults, so that I only specify the values I want to change.
-9. As a chart author, I want a clear, early error if I reference a values file that does not
-   exist or is misnamed, so that I catch mistakes before a cluster is touched.
-10. As a chart author, I want a clear error if I declare a controller name that the tool does not
-    know, so that I learn immediately that the tool cannot satisfy my suite.
-11. As a chart author, I want an already-present, compatible controller to be reused, so that
-    repeated runs on the same cluster do not pay the install cost again.
-12. As an operator, I want the run to fail if a present controller's version does not satisfy the
-    declared range, so that I am not silently testing against the wrong controller version.
-13. As an operator, I want the tool never to modify or remove a controller it finds already
-    installed, so that my shared cluster's controllers are not disrupted.
-14. As an operator, I want bootstrapped controllers to remain after the run, so that later runs
-    on the same cluster are faster.
-15. As a test-tool implementer, I want a precise, tool-neutral contract, so that my tool
-    interoperates with the same declaration files other tools use.
-16. As a test-tool implementer, I want my own tool-namespaced configuration key, so that my
-    install configuration does not collide with other tools' configuration in the shared file.
-17. As a test-tool implementer, I want the freedom to implement providers however I like, so that
-    I can install controllers in the way that suits my target clusters.
-18. As a test-tool implementer, I want the contract to define pre-install and post-install
-    extension points, so that controllers needing RBAC or webhook readiness can be supported.
-19. As a chart author consuming multiple tools, I want a single declaration file with per-tool
-    sections, so that I maintain my controller needs in one place.
-
-## Implementation Decisions
-
-- The shared declaration file is `.apptest/config.yaml`; this contract governs its
-  `controllers` section only. Unknown sections are ignored by a conforming tool.
-- The `controllers` list is ordered and order is semantically significant.
-- Each entry requires `name` (tool-neutral controller identifier) and `semver` (version range).
-- `semver` uses Masterminds/semver v3 range grammar (Flux `OCIRepository` / Helm `--version`
-  semantics); a tool resolves it to the highest satisfying version.
-- Per-controller, per-tool install configuration lives under `config.<tool-id>`; values are
-  file names ending in `.yaml`, resolved relative to the declaration file, layered over
-  controller defaults, and shipped inside the test suite.
-- Tool ids are centrally allocated in this document (`ats`, `atf` currently).
-- Providers are tool-owned. This contract does not prescribe a provider code shape, only the
-  behaviours a provider must support: report installed version (or absent), install a selected
-  version, run pre-install and post-install steps, and report readiness.
-- Presence policy: absent → install; present-and-satisfies → reuse; present-and-violates →
-  hard error. No upgrade/downgrade/replace of a pre-existing controller.
-- Bootstrapping is once-per-cluster-per-run and install-only (no teardown).
-- Configuration-level errors are detected before any cluster mutation.
-
-## Testing Decisions
-
-This contract is validated by each consuming tool's own test suite; see the
-[ATS spec](./ats-test-time-controllers.md#testing-decisions) for ATS's approach. A conforming
-tool should have tests that cover, as external behaviour:
-
-- Parsing and validating the declaration (valid, empty/absent, missing required fields,
-  bad/missing per-tool values file).
-- Unknown controller name → error.
-- Order preservation across the `controllers` list.
-- Presence outcomes: absent → install; present-and-satisfies → reuse/skip; present-and-violates
-  → error.
-- Values file layering when `config.<tool-id>` is present vs. absent.
-- Once-per-run bootstrapping across multiple test phases.
-
-Tests should assert on observable behaviour (what gets installed, in what order, with what
-configuration, and which errors are raised), not on provider internals.
-
-## Out of Scope
-
-- How a tool discovers, resolves, or overrides the path to the declaration file.
-- How a provider is implemented, packaged, or registered within a tool.
-- How a provider enumerates available versions or performs the install.
-- Sharing provider *code* between tools (only the declaration file is shared).
-- Per-chart pinning of exact controller versions beyond what `semver` expresses.
-- Bootstrapping anything other than controllers (e.g. standalone CRDs with no controller) —
-  though a future section of `.apptest/config.yaml` could add that.
-- Uninstalling or upgrading controllers.
-
-## Further Notes
-
-- The `config.<tool-id>` mechanism is intentionally extensible: adding a new consuming tool
-  means allocating a tool id and (optionally) authoring a new per-tool values file, without
-  changing the shared list of controller names.
-- Because pre-existing controllers are never modified, a cluster deliberately pre-provisioned
-  with a compatible controller will be reused as-is, which is the fast path for repeated runs.
+The normative definition of the schema, version semantics, install ordering, presence policy,
+lifecycle, runner flow, and error handling is the
+[RFC](https://github.com/giantswarm/rfc/pull/153). The app-test-suite specifics are in the
+[ATS implementation spec](./ats-test-time-controllers.md).

--- a/docs/specs/test-time-controllers-contract.md
+++ b/docs/specs/test-time-controllers-contract.md
@@ -1,0 +1,320 @@
+# Spec: Test-Time Controllers Bootstrap Contract
+
+> Status: draft · Scope: tool-independent contract
+>
+> This document defines a **tool-independent** contract for declaring and bootstrapping
+> the Kubernetes controllers a chart's test suite needs at test time. It is written to be
+> implemented by more than one test tool. It deliberately contains **no** concepts, option
+> names, file layouts, or behaviours specific to any single tool.
+>
+> For the concrete application of this contract to app-test-suite (ATS), see the companion
+> spec: [ATS Test-Time Controllers](./ats-test-time-controllers.md).
+
+## Problem Statement
+
+A Helm chart under test frequently creates custom resources (CRs) — for example a Flux
+`Kustomization`, an Argo CD `Application`, or an `ExternalSecret` — that only become
+meaningful when a matching **controller** is running on the test cluster to reconcile them.
+Without that controller, the API server may accept the CR (if its CRD is present) but nothing
+acts on it, so the chart never reaches a functional state and the tests cannot validate real
+behaviour.
+
+Which controllers a chart needs is specific to that chart. Only a subset of charts need any
+given controller, and deploying controllers is expensive (time and cluster resources).
+Deploying every possible controller for every chart is wasteful; guessing which ones a chart
+needs from its contents is fragile and flaky.
+
+Different test tools consume the same chart test suites. A chart declares its controller needs
+once; every tool that runs that suite must be able to read the same declaration and bootstrap
+the same set of controllers, even though each tool targets a different kind of cluster and may
+need different install-time configuration.
+
+## Solution
+
+A chart's test suite declares, **explicitly**, the exact set of controllers it needs, in a
+single well-known file that is part of the test suite. Any conforming test tool reads that file
+and, during its cluster-preparation phase, ensures each declared controller is present on the
+target cluster at an acceptable version before the chart is deployed and tested.
+
+- Declaration is **opt-in and explicit** — no auto-detection. A chart that declares nothing
+  gets nothing bootstrapped.
+- The declaration is **tool-neutral**: it names controllers and version ranges, and it carries
+  per-tool install configuration under tool-namespaced keys, so multiple tools can share one
+  file.
+- Each conforming tool owns its own **controller provider** implementations (how a named
+  controller is installed, detected, and made ready). The file is the shared contract; the
+  provider code is not.
+- A tool installs only the declared controllers, in declared order, and reuses controllers that
+  are already present.
+
+## Terminology
+
+- **Controller** — a Kubernetes workload (and its CRDs/RBAC) that reconciles a class of custom
+  resources (e.g. Flux, Argo CD, External Secrets).
+- **Controller name** — the stable, tool-neutral identifier of a controller (e.g. `flux`,
+  `argo`, `external-secrets`) used in the declaration and to look up a provider.
+- **Provider** — a tool-side implementation that knows how to detect, install, and ready a
+  particular controller. Providers are owned by each tool, not by this contract.
+- **Consuming tool** — a test tool that implements this contract (reads the declaration and
+  bootstraps controllers). Each consuming tool has a short **tool id** (see
+  [Tool ids](#tool-ids)).
+- **Target cluster** — the pre-existing cluster the consuming tool prepares and runs tests on.
+- **Test suite** — the chart-specific test assets, of which the declaration file is a part.
+
+## The declaration file
+
+### Location
+
+The declaration lives at `.apptest/config.yaml` within the test suite. The `.apptest/`
+directory is the shared, tool-neutral home for cross-tool testing declarations; this contract
+defines the `controllers` section of `config.yaml`. Other sections may be added by future
+contracts and must be ignored by a tool that does not understand them.
+
+How a tool discovers, resolves, or overrides the path to this file is tool-specific and out of
+scope for this contract. What is fixed is the filename and the schema below.
+
+### Schema
+
+```yaml
+controllers:
+  - name: <controller-name>        # required, string
+    semver: <version-range>        # required, string (see "Version selection")
+    config:                        # optional, mapping of tool id -> values file name
+      <tool-id>: <filename.yaml>   # optional per tool id
+      ...
+  - ...
+```
+
+- `controllers` — an ordered list. **Order is significant** (see
+  [Install ordering](#install-ordering)).
+- `name` — **required**. The tool-neutral controller name. If a consuming tool has no provider
+  registered for this name, that is a hard error (see [Error handling](#error-handling)).
+- `semver` — **required**. A version range (see [Version selection](#version-selection)).
+- `config` — **optional**. A mapping keyed by **tool id**. Each value is the file name of a
+  tool-specific install-configuration (values) file for this controller. See
+  [Per-tool configuration](#per-tool-configuration).
+
+A missing, empty, or absent `controllers` section means **no controllers are declared** and a
+conforming tool bootstraps nothing.
+
+### Tool ids
+
+Each consuming tool has a short, unique **tool id** used as its key under `config`. This keeps
+the shared file tool-neutral: a tool reads only its own key and ignores the others.
+
+Tool ids are allocated by this contract to avoid collisions. Currently allocated:
+
+- `ats` — app-test-suite (see [ATS spec](./ats-test-time-controllers.md))
+- `atf` — apptest-framework
+
+New consuming tools must allocate a new tool id here before using it.
+
+### Per-tool configuration
+
+The set of controllers a chart needs is tool-neutral, but the *configuration* used to install a
+controller often differs per tool, because each tool targets a different kind of cluster (for
+example a small local cluster vs. a full production-like cluster). Those install-time values
+therefore belong to the tool, not to the shared list of names.
+
+- Per-controller configuration is **optional**. If an entry has no `config` mapping, or no key
+  for the current tool's id, the controller is installed with its **default** configuration.
+- When present, `config.<tool-id>` names a **values file** authored by the test-suite author
+  and shipped inside the test suite (alongside the declaration file).
+- Each value **must** be a full file name ending in `.yaml`.
+- The named file is resolved relative to the declaration file's directory.
+- A conforming tool applies the file as install-time configuration **layered over the
+  controller's defaults** (i.e. an overlay, not a full replacement).
+- If `config.<tool-id>` names a file that does not exist, or a value that does not end in
+  `.yaml`, that is a hard error (see [Error handling](#error-handling)).
+
+Example:
+
+```yaml
+controllers:
+  - name: flux
+    semver: ">=2.0.0 <3.0.0"
+    config:
+      ats: flux-small.yaml      # used by app-test-suite
+      atf: flux-full.yaml       # used by apptest-framework
+  - name: external-secrets
+    semver: "0.x"
+    # no config -> each tool installs with the controller's default configuration
+```
+
+## Behaviour
+
+### Version selection
+
+`semver` is a **version range**, interpreted with the same semantics as Flux
+`OCIRepository` semver matching and Helm's `--version` constraint — i.e. the
+Masterminds/semver v3 range grammar. Examples: `1.2.x`, `>=1.0.0 <2.0.0`, `~1.2.3`, `^1.2.3`,
+`*`. Pre-releases are excluded unless the range explicitly names a pre-release. See
+<https://fluxcd.io/flux/components/source/ocirepositories/#semver-example>.
+
+A conforming tool resolves the range to the **highest available version that satisfies it** and
+installs that version. How available versions are enumerated (registry, chart repository, etc.)
+is provider-defined.
+
+### Install ordering
+
+Controllers are bootstrapped **sequentially, in the order they appear** in the `controllers`
+list. A controller must be fully installed **and ready** before the next controller in the list
+is started. Tools must not reorder or parallelise the list. Authors may therefore rely on order
+to express dependencies between controllers.
+
+### Presence detection and version policy
+
+Before installing a controller, a conforming tool must determine whether an acceptable instance
+is **already present** on the target cluster, and reuse it rather than reinstalling:
+
+- The provider reports the **installed version** of the controller on the target cluster, or
+  reports that it is **absent**. The version reported at detection time and the version selected
+  at install time are compared on the **same basis** (the chart version), so they are directly
+  comparable.
+- **Absent** → the tool installs the controller (resolving `semver` as above), then waits for it
+  to be ready.
+- **Present and the installed version satisfies `semver`** → the tool reuses it and skips
+  installation.
+- **Present but the installed version does not satisfy `semver`** → **hard error**. A conforming
+  tool must **not** upgrade, downgrade, or replace a controller it finds already present; the
+  mismatch fails the run so the operator can resolve it. (The rationale: the target cluster is
+  not owned by the tool, and silently changing an existing controller could break other
+  workloads.)
+
+### Provider setup hooks
+
+A controller install is not always a single package install. A provider may need to perform
+setup **before** installing (for example creating a `Role`/`RoleBinding` or applying prerequisite
+manifests) and additional work or readiness checks **after** installing (for example waiting for
+a webhook or a freshly-installed CRD to become established). The contract therefore requires that
+a provider be able to run arbitrary **pre-install** and **post-install** steps around the install,
+in addition to the declarative common case.
+
+### Readiness
+
+"Ready" means the controller's workloads report healthy **and** any provider-defined
+post-install readiness checks have passed. A controller is only considered bootstrapped once it
+is ready. Because installs are sequential, the readiness of controller *N* is guaranteed before
+controller *N+1* begins.
+
+### Idempotency and lifecycle
+
+- Bootstrapping is performed **once per target cluster per run**, shared across all test phases
+  in that run.
+- Bootstrapped controllers are **installed only — never uninstalled** by the tool. They are
+  treated as durable cluster infrastructure. Leaving them in place makes subsequent runs on the
+  same cluster faster and avoids removing something another chart or run may depend on.
+
+### Error handling
+
+The following are **hard errors** that must be surfaced clearly:
+
+- A declared `name` has no registered provider in the consuming tool.
+- A declaration entry is missing a required field (`name` or `semver`).
+- `config.<tool-id>` names a non-existent file or a value not ending in `.yaml`.
+- `semver` resolves to no available version.
+- A controller is present but its installed version does not satisfy `semver`.
+- An install, readiness wait, or provider setup hook fails.
+
+Configuration-level errors (the first three) should be detected as early as possible — before
+any cluster changes are made — so a misconfigured suite fails fast. Where exactly a tool
+performs this validation is tool-specific.
+
+## User Stories
+
+1. As a chart/test-suite author, I want to declare the controllers my chart needs in one file,
+   so that any test tool can bootstrap them consistently.
+2. As a chart author, I want to declare a controller by name and version range, so that I get a
+   compatible version without pinning an exact release.
+3. As a chart author, I want controllers I did not declare to never be installed, so that my
+   test runs stay fast and cheap.
+4. As a chart author, I want no controller auto-detection, so that my test setup is explicit and
+   not flaky.
+5. As a chart author, I want to declare controllers in a specific order, so that a controller
+   that depends on another is bootstrapped after it.
+6. As a chart author, I want to optionally provide per-tool install configuration for a
+   controller, so that the same controller can be tuned for a small cluster in one tool and a
+   full cluster in another.
+7. As a chart author, I want a controller with no per-tool configuration to install with sensible
+   defaults, so that I only write configuration when I actually need to override something.
+8. As a chart author, I want my per-tool values file to be layered over the controller's
+   defaults, so that I only specify the values I want to change.
+9. As a chart author, I want a clear, early error if I reference a values file that does not
+   exist or is misnamed, so that I catch mistakes before a cluster is touched.
+10. As a chart author, I want a clear error if I declare a controller name that the tool does not
+    know, so that I learn immediately that the tool cannot satisfy my suite.
+11. As a chart author, I want an already-present, compatible controller to be reused, so that
+    repeated runs on the same cluster do not pay the install cost again.
+12. As an operator, I want the run to fail if a present controller's version does not satisfy the
+    declared range, so that I am not silently testing against the wrong controller version.
+13. As an operator, I want the tool never to modify or remove a controller it finds already
+    installed, so that my shared cluster's controllers are not disrupted.
+14. As an operator, I want bootstrapped controllers to remain after the run, so that later runs
+    on the same cluster are faster.
+15. As a test-tool implementer, I want a precise, tool-neutral contract, so that my tool
+    interoperates with the same declaration files other tools use.
+16. As a test-tool implementer, I want my own tool-namespaced configuration key, so that my
+    install configuration does not collide with other tools' configuration in the shared file.
+17. As a test-tool implementer, I want the freedom to implement providers however I like, so that
+    I can install controllers in the way that suits my target clusters.
+18. As a test-tool implementer, I want the contract to define pre-install and post-install
+    extension points, so that controllers needing RBAC or webhook readiness can be supported.
+19. As a chart author consuming multiple tools, I want a single declaration file with per-tool
+    sections, so that I maintain my controller needs in one place.
+
+## Implementation Decisions
+
+- The shared declaration file is `.apptest/config.yaml`; this contract governs its
+  `controllers` section only. Unknown sections are ignored by a conforming tool.
+- The `controllers` list is ordered and order is semantically significant.
+- Each entry requires `name` (tool-neutral controller identifier) and `semver` (version range).
+- `semver` uses Masterminds/semver v3 range grammar (Flux `OCIRepository` / Helm `--version`
+  semantics); a tool resolves it to the highest satisfying version.
+- Per-controller, per-tool install configuration lives under `config.<tool-id>`; values are
+  file names ending in `.yaml`, resolved relative to the declaration file, layered over
+  controller defaults, and shipped inside the test suite.
+- Tool ids are centrally allocated in this document (`ats`, `atf` currently).
+- Providers are tool-owned. This contract does not prescribe a provider code shape, only the
+  behaviours a provider must support: report installed version (or absent), install a selected
+  version, run pre-install and post-install steps, and report readiness.
+- Presence policy: absent → install; present-and-satisfies → reuse; present-and-violates →
+  hard error. No upgrade/downgrade/replace of a pre-existing controller.
+- Bootstrapping is once-per-cluster-per-run and install-only (no teardown).
+- Configuration-level errors are detected before any cluster mutation.
+
+## Testing Decisions
+
+This contract is validated by each consuming tool's own test suite; see the
+[ATS spec](./ats-test-time-controllers.md#testing-decisions) for ATS's approach. A conforming
+tool should have tests that cover, as external behaviour:
+
+- Parsing and validating the declaration (valid, empty/absent, missing required fields,
+  bad/missing per-tool values file).
+- Unknown controller name → error.
+- Order preservation across the `controllers` list.
+- Presence outcomes: absent → install; present-and-satisfies → reuse/skip; present-and-violates
+  → error.
+- Values file layering when `config.<tool-id>` is present vs. absent.
+- Once-per-run bootstrapping across multiple test phases.
+
+Tests should assert on observable behaviour (what gets installed, in what order, with what
+configuration, and which errors are raised), not on provider internals.
+
+## Out of Scope
+
+- How a tool discovers, resolves, or overrides the path to the declaration file.
+- How a provider is implemented, packaged, or registered within a tool.
+- How a provider enumerates available versions or performs the install.
+- Sharing provider *code* between tools (only the declaration file is shared).
+- Per-chart pinning of exact controller versions beyond what `semver` expresses.
+- Bootstrapping anything other than controllers (e.g. standalone CRDs with no controller) —
+  though a future section of `.apptest/config.yaml` could add that.
+- Uninstalling or upgrading controllers.
+
+## Further Notes
+
+- The `config.<tool-id>` mechanism is intentionally extensible: adding a new consuming tool
+  means allocating a tool id and (optionally) authoring a new per-tool values file, without
+  changing the shared list of controller names.
+- Because pre-existing controllers are never modified, a cluster deliberately pre-provisioned
+  with a compatible controller will be reused as-is, which is the fast path for repeated runs.


### PR DESCRIPTION
## What

Adds two cross-referenced spec documents for the **test-time controllers** feature — a way for a chart's test suite to declare the Kubernetes controllers it needs (e.g. Flux, Argo CD, External Secrets) so the test tool bootstraps exactly those on the target cluster before deploying the chart under test.

- **`docs/specs/test-time-controllers-contract.md`** — the **tool-independent** contract for the shared `.apptest/config.yaml` declaration. Defines the schema (`controllers[]` with `name` + `semver` + optional per-tool `config.<tool-id>` values files), `semver` semantics (Masterminds/semver v3, Flux `OCIRepository` / Helm `--version` parity), significant install ordering, presence-detection + version policy, provider pre/post-install hooks, install-only lifecycle, and error handling. Carries no ATS-specific concepts; allocates tool ids (`ats`, `atf`) so app-test-suite and apptest-framework can share one file.
- **`docs/specs/ats-test-time-controllers.md`** — how **app-test-suite** applies the contract: a data-driven `Controller` base class + `__init_subclass__` registry, a `ControllerManager` mirroring `ClusterManager`, Helm-based install from the Giant Swarm catalog (`semver` → `helm --version`), CLI surface (`--controllers-config-file`, `--skip-controllers`), pipeline placement (CRD bundle → controllers → app), once-per-run guard, and the test seams.

## Notes

- **Specs only — no code.** The ATS spec is scoped to ship the **framework first, zero concrete providers**; the existing providers are synced in later.
- **Additive**: the existing `--cluster-crds` bundle is untouched.
- The two docs cross-reference each other and agree on every shared decision (required fields, ordering, presence policy, lifecycle, `config.ats`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)