### PR TITLE
feat: accept .ats/main.yml as well as .ats/main.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), following
 
 ### Added
 
+- `.ats/main.yml` is now also recognized as the ATS config file, alongside the canonical `.ats/main.yaml`. When both exist, `.yaml` still wins.
 - Test executor auto-detection: with `--test-executor` left at its new default `auto`, the executor is chosen from the test directory — a `go.mod` selects `gotest`, a `pyproject.toml` selects `pytest`. Pass `pytest`/`gotest` explicitly to override (for example when the directory is empty or contains both markers). The bundled example app (`examples/apps/hello-world-app`) now ships a `tests/ats` Python suite and a `tests/ats-gotest` Go suite you can switch between with `--tests-dir`.
 - `ats` can now be installed directly as a Python CLI tool with `uv tool install app-test-suite` (published to PyPI on every `v*` tag via OIDC trusted publishing). In this mode you provide the required binaries (`helm`, `kubectl`, and `go` as needed) yourself, without pulling the Docker image. See the README "With uv" section.
 - OCI catalog URLs (`oci://...`) are now supported for `--upgrade-tests-app-catalog-url`; `helm pull oci://<url>/<chart>` is used automatically.

--- a/app_test_suite/__main__.py
+++ b/app_test_suite/__main__.py
@@ -197,20 +197,24 @@ def configure_test_specific_options(config_parser: configargparse.ArgParser) -> 
     )
 
 
+# .yml is listed before .yaml, so .yaml wins when a directory has both.
+# This keeps the canonical name authoritative while still accepting the shorter extension.
+_CONFIG_FILE_NAMES = ("main.yml", "main.yaml")
+
+
 def get_default_config_file_paths() -> List[str]:
     base_dir = os.getcwd()
     # The config file is looked up relative to the executing directory (the current working directory),
     # so it can be provided independently of where the chart archive lives (see issue #196).
-    cwd_config_path = os.path.join(base_dir, ".ats", "main.yaml")
-    config_paths = [cwd_config_path]
+    cwd_ats_dir = os.path.join(base_dir, ".ats")
+    config_paths = [os.path.join(cwd_ats_dir, name) for name in _CONFIG_FILE_NAMES]
     # Backward compatibility: also look for the config next to the chart file. When both files exist,
     # the chart-file-relative one is parsed last and thus takes precedence, preserving legacy behaviour.
     chart_file = get_chart_file_from_argv()
     if chart_file:
-        chart_dir = os.path.dirname(chart_file)
-        chart_config_path = os.path.join(base_dir, chart_dir, ".ats", "main.yaml")
-        if os.path.normpath(chart_config_path) != os.path.normpath(cwd_config_path):
-            config_paths.append(chart_config_path)
+        chart_ats_dir = os.path.join(base_dir, os.path.dirname(chart_file), ".ats")
+        if os.path.normpath(chart_ats_dir) != os.path.normpath(cwd_ats_dir):
+            config_paths += [os.path.join(chart_ats_dir, name) for name in _CONFIG_FILE_NAMES]
     logger.debug(f"Using {config_paths} as configuration file path candidates.")
     return config_paths
 

--- a/tests/test_config_file_discovery.py
+++ b/tests/test_config_file_discovery.py
@@ -1,0 +1,68 @@
+"""Tests for ATS config file discovery in __main__.
+
+.ats/main.yaml is the canonical config file name; .ats/main.yml is also
+accepted so repos that default to the shorter YAML extension don't silently
+have their overrides ignored.
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+
+from app_test_suite.__main__ import get_default_config_file_paths
+
+
+def test_cwd_yaml_only(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    ats_dir = tmp_path / ".ats"
+    ats_dir.mkdir()
+    (ats_dir / "main.yaml").write_text("smoke-tests-cluster-type: kind\n")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr("sys.argv", ["ats", "--debug"])
+
+    paths = get_default_config_file_paths()
+
+    assert os.path.join(str(tmp_path), ".ats", "main.yaml") in paths
+
+
+def test_cwd_yml_only(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    ats_dir = tmp_path / ".ats"
+    ats_dir.mkdir()
+    (ats_dir / "main.yml").write_text("smoke-tests-cluster-type: kind\n")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr("sys.argv", ["ats", "--debug"])
+
+    paths = get_default_config_file_paths()
+
+    assert os.path.join(str(tmp_path), ".ats", "main.yml") in paths
+
+
+def test_yaml_takes_precedence_over_yml_when_both_present(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    ats_dir = tmp_path / ".ats"
+    ats_dir.mkdir()
+    (ats_dir / "main.yml").write_text("smoke-tests-cluster-type: external\n")
+    (ats_dir / "main.yaml").write_text("smoke-tests-cluster-type: kind\n")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr("sys.argv", ["ats", "--debug"])
+
+    paths = get_default_config_file_paths()
+
+    yml_path = os.path.join(str(tmp_path), ".ats", "main.yml")
+    yaml_path = os.path.join(str(tmp_path), ".ats", "main.yaml")
+    # .yaml must be parsed last so it wins when both files set the same key
+    assert paths.index(yml_path) < paths.index(yaml_path)
+
+
+def test_chart_relative_yml_is_also_a_candidate(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    root = tmp_path / "root"
+    chart_ats_dir = root / "sub" / ".ats"
+    chart_ats_dir.mkdir(parents=True)
+    (chart_ats_dir / "main.yml").write_text("functional-tests-cluster-type: kind\n")
+    chart_file = root / "sub" / "mychart.tgz"
+    chart_file.write_text("x")
+    monkeypatch.chdir(root)
+    monkeypatch.setattr("sys.argv", ["ats", "-c", str(chart_file)])
+
+    paths = get_default_config_file_paths()
+
+    assert os.path.join(str(root), "sub", ".ats", "main.yml") in paths


### PR DESCRIPTION
This PR adds the ability to also have a main.yml file. 
A user of app-test-suite might expect that to work and be confused when the file is completely ignored instead.
.yaml takes precedence over .yml provided values.